### PR TITLE
Break out operator configuration and startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ vet: ## Run go vet against code.
 
 test: manifests generate fmt vet ## Run unit tests
 		go test \
-		-mod=readonly \
 		-covermode=atomic \
 		-coverprofile coverage.out \
 		./...

--- a/cmd/externaldns-operator/main.go
+++ b/cmd/externaldns-operator/main.go
@@ -24,40 +24,23 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
-	"github.com/openshift/external-dns-operator/controllers"
+	"github.com/openshift/external-dns-operator/pkg/operator"
+	operatorconfig "github.com/openshift/external-dns-operator/pkg/operator/config"
 	//+kubebuilder:scaffold:imports
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	opCfg operatorconfig.Config
 )
 
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
-}
-
 func main() {
-	var metricsAddr string
-	var probeAddr string
-	var operatorNamespace string
-	var operandNamespace string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "127.0.0.1:8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", "127.0.0.1:8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&operatorNamespace, "operator-namespace", "externaldns-operator", "The namespace that the operator is running in.")
-	flag.StringVar(&operandNamespace, "operand-namespace", "externaldns", "The namespace that ExternalDNS instances should run in.")
+	flag.StringVar(&opCfg.MetricsBindAddress, "metrics-bind-address", operatorconfig.DefaultMetricsAddr, "The address the metric endpoint binds to.")
+	flag.StringVar(&opCfg.OperatorNamespace, "operator-namespace", operatorconfig.DefaultOperatorNamespace, "The namespace that the operator is running in.")
+	flag.StringVar(&opCfg.OperandNamespace, "operand-namespace", operatorconfig.DefaultOperandNamespace, "The namespace that ExternalDNS containers should run in.")
+	flag.StringVar(&opCfg.ExternalDNSImage, "externaldns-image", operatorconfig.DefaultExternalDNSImage, "The container image used for running ExternalDNS.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -65,48 +48,20 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-	ctrl.Log.Info("Using operator namespace", "namespace", operatorNamespace)
-	ctrl.Log.Info("Using operand namespace", "namespace", operandNamespace)
+	setupLog := ctrl.Log.WithName("setup")
+	ctrl.Log.Info("using operator namespace", "namespace", opCfg.OperatorNamespace)
+	ctrl.Log.Info("using operand namespace", "namespace", opCfg.OperandNamespace)
+	ctrl.Log.Info("using ExternalDNS image", "image", opCfg.ExternalDNSImage)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		Namespace:              operatorNamespace,
-		NewCache: cache.MultiNamespacedCacheBuilder([]string{
-			operatorNamespace,
-			operandNamespace,
-		}),
-	})
+	op, err := operator.New(ctrl.GetConfigOrDie(), &opCfg)
 	if err != nil {
-		setupLog.Error(err, "unable to start operator")
+		setupLog.Error(err, "failed to create externaldns operator")
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ExternalDNSReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		OperatorNamespace: operatorNamespace,
-		OperandNamespace:  operandNamespace,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ExternalDNS")
-		os.Exit(1)
-	}
-	//+kubebuilder:scaffold:builder
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-
-	setupLog.Info("starting operator")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running operator")
+	setupLog.Info("starting externalDNS operator")
+	if err := op.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "failed to start externaldns operator")
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/external-dns-operator
 go 1.16
 
 require (
+	github.com/go-logr/logr v0.4.0
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1
 	sigs.k8s.io/controller-runtime v0.9.0

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	DefaultExternalDNSImage  = "docker.io/bitnami/external-dns:latest"
+	DefaultMetricsAddr       = "127.0.0.1:8080"
+	DefaultOperatorNamespace = "externaldns-operator"
+	DefaultOperandNamespace  = "externaldns"
+)
+
+// Config is configuration of the operator.
+type Config struct {
+	// ExternalDNSImage is the ExternalDNS image for the ExternalDNS container(s) managed
+	// by the operator.
+	ExternalDNSImage string
+
+	// MetricsBindAddress is the TCP address that the operator should bind to for
+	// serving prometheus metrics. It can be set to "0" to disable the metrics serving.
+	MetricsBindAddress string
+
+	// OperatorNamespace is the namespace that the operator is deployed in.
+	OperatorNamespace string
+
+	// OperandNamespace is the namespace that the operator should deploy ExternalDNS container(s) in.
+	OperandNamespace string
+}
+
+// New returns an operator config using default values.
+func New() *Config {
+	return &Config{
+		ExternalDNSImage:   DefaultExternalDNSImage,
+		MetricsBindAddress: DefaultMetricsAddr,
+		OperatorNamespace:  DefaultOperatorNamespace,
+		OperandNamespace:   DefaultOperandNamespace,
+	}
+}

--- a/pkg/operator/controller/externaldns/controller.go
+++ b/pkg/operator/controller/externaldns/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package externaldnscontroller
 
 import (
 	"context"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	operatorconfig "github.com/openshift/external-dns-operator/pkg/operator/config"
+	"github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns"
+)
+
+const (
+	operatorName = "externaldns_operator"
+)
+
+// Clients holds the API clients required by Operator.
+type Client struct {
+	client.Client
+	meta.RESTMapper
+}
+
+// Operator hold the client, manager, and logging resources
+// for the ExternalDNS opreator.
+type Operator struct {
+	client  Client
+	manager manager.Manager
+	log     logr.Logger
+}
+
+// New creates a new operator from cliCfg and opCfg.
+func New(cliCfg *rest.Config, opCfg *operatorconfig.Config) (*Operator, error) {
+	mgrOpts := manager.Options{
+		Scheme:             GetOperatorScheme(),
+		MetricsBindAddress: opCfg.MetricsBindAddress,
+		Namespace:          opCfg.OperatorNamespace,
+		NewCache: cache.MultiNamespacedCacheBuilder([]string{
+			opCfg.OperatorNamespace,
+			opCfg.OperandNamespace,
+		})}
+
+	mgr, err := ctrl.NewManager(cliCfg, mgrOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	if err = (&externaldnscontroller.ExternalDNSReconciler{
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		OperatorNamespace: opCfg.OperatorNamespace,
+		OperandNamespace:  opCfg.OperandNamespace,
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("failed to create externaldns controller: %w", err)
+	}
+
+	restMapper, err := apiutil.NewDiscoveryRESTMapper(cliCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Operator{
+		manager: mgr,
+		client:  Client{mgr.GetClient(), restMapper},
+		log:     ctrl.Log.WithName(operatorName),
+	}, nil
+}
+
+// Start starts the operator synchronously until a message is received from ctx.
+func (o *Operator) Start(ctx context.Context) error {
+	return o.manager.Start(ctx)
+}

--- a/pkg/operator/scheme.go
+++ b/pkg/operator/scheme.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+var (
+	// scheme contains all the API types necessary for the operator's dynamic
+	// clients to work. Any new non-core types must be added here.
+	//
+	// NOTE: The discovery mechanism used by the client doesn't automatically
+	// refresh, so only add types here that are guaranteed to exist before the
+	// operator starts.
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := operatorv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+}
+
+// GetOperatorScheme returns a scheme with types supported by the operator.
+func GetOperatorScheme() *runtime.Scheme {
+	return scheme
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,6 +28,7 @@ github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/go-logr/logr v0.4.0
+## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.4.0
 github.com/go-logr/zapr


### PR DESCRIPTION
**Makefile: Drop -mod=readonly from test directive**

Remove the `-mod=readonly` option from the unit test directive to ensure that we are using the `vendor` directory for unit tests.

**go.mod Add go-logr dependency**
go.mod:
Explicitly add go-logr in support of `operator.go`.

vendor/modules.txt:
Run `go mod vendor`.

**Break out operator configuration and startup**

controllers/externaldns_controller.go ->
pkg/operator/controller/externaldns/controller.go:

Move the exteraldns controller.go to a subdir of the new `controller` directory. Update the package name used for the controller.

pkg/operator/operator.go:
New file. Implements operator `New(...)` and `Start(...)` functions to move startup logic code out of `cmd/`.

pkg/operator/config/config.go:
New file to define options necessary to start the operator.

pkg/operator/scheme.go:
New file to define the API types necessary for the operator's clients to work. Implements `GetOperatorScheme` to relocate startup logic from `cmd/`.

cmd/externaldns-operator/main.go:
Strip out relocated code in an attempt to minimize code/logic in `cmd/`.