### PR TITLE
Iterate on externaldnscontroller and add basic namespace reconciliation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,17 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - operator.openshift.io
   resources:
   - externaldns

--- a/pkg/operator/controller/externaldns/controller.go
+++ b/pkg/operator/controller/externaldns/controller.go
@@ -35,19 +35,6 @@ type ExternalDNSReconciler struct {
 	OperandNamespace  string
 }
 
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns/finalizers,verbs=update
-
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ExternalDNS object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 

--- a/pkg/operator/controller/externaldns/controller.go
+++ b/pkg/operator/controller/externaldns/controller.go
@@ -18,6 +18,7 @@ package externaldnscontroller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -27,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -74,9 +75,13 @@ func New(mgr manager.Manager, cfg Config) (controller.Controller, error) {
 // Reconcile reconciles watched objects and attempts to make the current state of
 // the object match the desired state.
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	result := reconcile.Result{}
 
-	// your logic here
+	if _, _, err := r.ensureExternalDNSNamespace(ctx, r.config.Namespace); err != nil {
+		// Return if the externalDNS namespace cannot be created since
+		// resource creation in a namespace that does not exist will fail.
+		return result, fmt.Errorf("failed to ensure externalDNS namespace: %v", err)
+	}
 
-	return ctrl.Result{}, nil
+	return result, nil
 }

--- a/pkg/operator/controller/externaldns/controller.go
+++ b/pkg/operator/controller/externaldns/controller.go
@@ -19,33 +19,64 @@ package externaldnscontroller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/go-logr/logr"
 
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// ExternalDNSReconciler reconciles a ExternalDNS object
-type ExternalDNSReconciler struct {
-	client.Client
-	Scheme            *runtime.Scheme
-	OperatorNamespace string
-	OperandNamespace  string
+const (
+	controllerName = "externaldns_controller"
+)
+
+// Config holds all the things necessary for the controller to run.
+type Config struct {
+	// Namespace is the namespace that ExternalDNS should be deployed in.
+	Namespace string
+	// Image is the ExternalDNS image to use.
+	Image string
 }
 
-func (r *ExternalDNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// reconciler reconciles an ExternalDNS object.
+type reconciler struct {
+	config Config
+	client client.Client
+	log    logr.Logger
+}
+
+// New creates the externaldns controller from mgr and cfg. The controller will be pre-configured
+// to watch for ExternalDNS objects across all namespaces.
+func New(mgr manager.Manager, cfg Config) (controller.Controller, error) {
+	r := &reconciler{
+		config: cfg,
+		client: mgr.GetClient(),
+		log:    ctrl.Log.WithName(controllerName),
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Watch(&source.Kind{Type: &operatorv1alpha1.ExternalDNS{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Reconcile reconciles watched objects and attempts to make the current state of
+// the object match the desired state.
+func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
 	// your logic here
 
 	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *ExternalDNSReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.ExternalDNS{}).
-		Complete(r)
 }

--- a/pkg/operator/controller/externaldns/namespace.go
+++ b/pkg/operator/controller/externaldns/namespace.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureExternalDNSNamespace ensures that the externaldns namespace exists.
+func (r *reconciler) ensureExternalDNSNamespace(ctx context.Context, namespace string) (bool, *corev1.Namespace, error) {
+	desired := desiredExternalDNSNamespace(namespace)
+
+	haveNamespace, current, err := r.currentExternalDNSNamespace(ctx, namespace)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if !haveNamespace {
+		if err := r.createExternalDNSNamespace(ctx, desired); err != nil {
+			return false, nil, err
+		}
+		return r.currentExternalDNSNamespace(ctx, namespace)
+	}
+
+	return true, current, nil
+}
+
+// currentExternalDNSNamespace  gets the current externalDNS namespace resource.
+func (r *reconciler) currentExternalDNSNamespace(ctx context.Context, namespace string) (bool, *corev1.Namespace, error) {
+	ns := &corev1.Namespace{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, ns, nil
+
+}
+
+// desiredExternalDNSNamespace returns the desired namespace resource.
+func desiredExternalDNSNamespace(namespace string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			//TODO: Add more fields here? Labels?
+		},
+	}
+}
+
+// createExternalDNSNamespace creates the given namespace using the reconciler's
+// client.
+func (r *reconciler) createExternalDNSNamespace(ctx context.Context, ns *corev1.Namespace) error {
+	if err := r.client.Create(ctx, ns); err != nil {
+		return fmt.Errorf("failed to create externalDNS namespace %s: %v", ns.Name, err)
+	}
+
+	r.log.Info("created externaldns namespace", "namespace", ns.Name)
+	return nil
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -52,6 +52,12 @@ type Operator struct {
 	log     logr.Logger
 }
 
+// Aggregate kubebuilder RBAC tags in one location for simplicity.
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=externaldns/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;delete;create;update
+
 // New creates a new operator from cliCfg and opCfg.
 func New(cliCfg *rest.Config, opCfg *operatorconfig.Config) (*Operator, error) {
 	mgrOpts := manager.Options{


### PR DESCRIPTION
This PR consists of the following commits:


**Move kubebuilder RBAC tags to operator.go**

pkg/operator/controller/externaldns/controller.go:
Remove kubebuilder RBAC tags.

pkg/operator/operator.go:
Move kubebuilder RBAC tags to all live in a single
location in operator.go. Add RBAC tags for namespace permissions.

config/rbac/role.yaml:
Run `make manifests`.

**externaldnscontroller: Implement New(...) function**
6a6a96f
pkg/operator/controller/externaldns/controller.go:

Implement a `New(...)` function for creating the externaldns
controller with customizations.

pkg/operator/operator.go:
Update externaldns controller creation calls.

Use a non-caching client, similair to that in the
ingress and DNS operators.

**externaldns: Add basic namespace reconciliation logic** 

pkg/operator/controller/externaldns/namespace.go:

Add necessary functions to implement
`ensureExternalDNSNamespace`.

pkg/operator/controller/externaldns/controller.go:

Call `ensureExternalDNSNamespace` from the reconcile loop
of the externaldns controller.