### PR TITLE
Add verify command for OpenShift CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ test: manifests generate fmt vet ## Run unit tests
 		-coverprofile coverage.out \
 		./...
 
+verify:
+	hack/verify-gofmt.sh
+	hack/verify-deps.sh
+	hack/verify-generated.sh
+
 ##@ Build
 
 GO=GO111MODULE=on GOFLAGS=-mod=vendor CGO_ENABLED=0 go

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the vendor tree following 'go mod vendor' and 'go mod tidy'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  go mod vendor
+  go mod tidy
+
+  test -z "$(git status --porcelain)" || print_failure
+  echo "verified Go modules"
+fi

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the tree when running 'make generate' and `make manifests`. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  make generate
+  make manifests
+
+  test -z "$(git status --porcelain)" || print_failure
+  echo "verified generated manifests and deep copy"
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+go_files=$( find . -name '*.go' -not -path './vendor/*' -print )
+bad_files=$(gofmt -s -l ${go_files})
+if [[ -n "${bad_files}" ]]; then
+    (>&2 echo "!!! gofmt needs to be run on the listed files")
+	echo "${bad_files}"
+    (>&2 echo "Try running 'gofmt -s -d [path]' or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'")
+    exit 1
+fi


### PR DESCRIPTION
hack/verify-deps.sh:
Add script to verify `vendor/` when running on OpenShift CI.

hack/verify-gofmt.sh:
Add script to verify that all operator code is gofmt compliant.

hack/verify-generated.sh:
Add script to verify that generated manifests (e.g. the ExternalDNS CRD)
and deep copy functions are up to date.

Makefile:
Add new `verify` directive that calls the verify scripts in `hack/`.

/assign @alebedev87 