### PR TITLE
go.mod: Explicitly add k8s API dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
+	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1
 	sigs.k8s.io/controller-runtime v0.9.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,6 +209,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3
 # k8s.io/api v0.21.1
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1


### PR DESCRIPTION
https://github.com/openshift/external-dns-operator/pull/9
imported a dependency without explicitly adding it to
go.mod or vendor. This commit fixes that.

---

This is a follow up to #13 and will save us a slight headache when we add the verify CI job.
/cc @alebedev87 