### PR TITLE
Make deployable manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ external DNS records in specific DNS Providers for specific Kubernetes resources
 
 This Operator is in the early stages of implementation. For the time being, please reference the
 [ExternalDNS Operator OpenShift Enhancement Proposal](https://github.com/openshift/enhancements/pull/786).
+
+## Deploy operator
+
+### Quick development
+1. Build and push the operator image to a registry:
+   ```sh
+   $ podman build -t <registry>/<username>/external-dns-operator:latest -f Dockerfile .
+   $ podman push <registry>/<username>/external-dns-operator:latest
+   ```
+2. Make sure to uncomment the `image` in `config/manager/kustomization.yaml` and set it to the operator image you pushed
+3. Run `oc apply -k config/default`

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: test-system
+namespace: external-dns-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: test-
+#namePrefix: test-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,8 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
 spec:
   template:
     spec:
@@ -19,7 +18,10 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      - name: operator
         args:
-        - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,13 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
 spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: operator
         args:
         - "--config=controller_manager_config.yaml"
         volumeMounts:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,10 +1,16 @@
 resources:
 - manager.yaml
 
+# Uncomment the following lines to override the operator's image with the image of your choice (i.e. personal registry).
+#images:
+#  - name: quay.io/openshift/origin-external-dns-operator
+#    newName: quay.io/alebedev87/external-dns-operator
+#    newTag: latest
+
 generatorOptions:
   disableNameSuffixHash: true
 
-configMapGenerator:
-- name: manager-config
-  files:
-  - controller_manager_config.yaml
+#configMapGenerator:
+#- name: manager-config
+#  files:
+#  - controller_manager_config.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,53 +2,44 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
-  name: system
+    name: external-dns-operator
+  name: external-dns-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
+  namespace: external-dns-operator
   labels:
-    control-plane: controller-manager
+    name: external-dns-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: external-dns-operator
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        name: external-dns-operator
     spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        image: controller:latest
-        name: manager
+      - name: operator
+        image: quay.io/openshift/origin-external-dns-operator:latest
+        args:
+        - --operator-namespace=$(OPERATOR_NAMESPACE)
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
-            memory: 20Mi
-      serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10
+            memory: 30Mi
+      serviceAccountName: external-dns-operator

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: external-dns-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: proxy-role
+  name: external-dns-operator-auth-proxy
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: proxy-rolebinding
+  name: external-dns-operator-auth-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: proxy-role
+  name: external-dns-operator-auth-proxy
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
+  namespace: external-dns-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
-  namespace: system
+    name: external-dns-operator
+  name: external-dns-operator-metrics-service
+  namespace: external-dns-operator
 spec:
   ports:
   - name: https
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    name: external-dns-operator

--- a/config/rbac/externaldns_editor_role.yaml
+++ b/config/rbac/externaldns_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: externaldns-editor-role
+  name: externaldns-editor
 rules:
 - apiGroups:
   - operator.openshift.io

--- a/config/rbac/externaldns_viewer_role.yaml
+++ b/config/rbac/externaldns_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: externaldns-viewer-role
+  name: externaldns-viewer
 rules:
 - apiGroups:
   - operator.openshift.io

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
-- leader_election_role.yaml
-- leader_election_role_binding.yaml
+#- leader_election_role.yaml
+#- leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: external-dns-operator
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: external-dns-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: external-dns-operator
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
+  namespace: external-dns-operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
-  namespace: system
+  name: external-dns-operator
+  namespace: external-dns-operator


### PR DESCRIPTION
Preparation for OLM bundle as it has to include the deployment's spec and roles. As a positive side effect we can now use the manifests to deploy the operator on a cluster.

- Changed names for deployment, service account and other resources to better reflect the deliverable
- Updated deployment spec (resources, probes)
- Commented not used manifests (manager config, leader election)

```sh
$ oc apply -k config/default
namespace/external-dns-operator created
customresourcedefinition.apiextensions.k8s.io/externaldns.operator.openshift.io created
serviceaccount/external-dns-operator created
clusterrole.rbac.authorization.k8s.io/external-dns-operator-metrics-reader created
clusterrole.rbac.authorization.k8s.io/external-dns-operator created
clusterrole.rbac.authorization.k8s.io/proxy-role created
clusterrolebinding.rbac.authorization.k8s.io/external-dns-operator created
clusterrolebinding.rbac.authorization.k8s.io/proxy-rolebinding created
service/external-dns-operator-metrics-service created
deployment.apps/external-dns-operator created

$ oc -n external-dns-operator get pods
NAME                                     READY   STATUS    RESTARTS   AGE
external-dns-operator-7557bd6f49-m2rk8   2/2     Running   0          4m47s

$ oc -n external-dns-operator logs external-dns-operator-7557bd6f49-m2rk8   -c operator
2021-07-13T09:00:00.830Z	INFO	using operator namespace	{"namespace": "externaldns-operator"}
2021-07-13T09:00:00.830Z	INFO	using operand namespace	{"namespace": "externaldns"}
2021-07-13T09:00:00.830Z	INFO	using ExternalDNS image	{"image": "docker.io/bitnami/external-dns:latest"}
I0713 09:00:01.881418       1 request.go:668] Waited for 1.033829744s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/migration.k8s.io/v1alpha1?timeout=32s
2021-07-13T09:00:03.639Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2021-07-13T09:00:06.443Z	INFO	setup	starting externalDNS operator
2021-07-13T09:00:06.443Z	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
2021-07-13T09:00:06.444Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting EventSource	{"source": "kind source: /, Kind="}
2021-07-13T09:00:06.444Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting Controller
2021-07-13T09:00:06.646Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting workers	{"worker count": 1}

```