### PR TITLE
Add OLM bundle

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,0 +1,13 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=external-dns-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,6 +5,8 @@ RUN make build-operator
 
 FROM registry.ci.openshift.org/ocp/4.9:base
 COPY --from=builder /external-dns-operator/bin/external-dns-operator /usr/bin/
+COPY --from=builder /external-dns-operator/bundle/manifests /manifests
+COPY --from=builder /external-dns-operator/bundle/metadata /metadata
 ENTRYPOINT ["/usr/bin/external-dns-operator"]
 LABEL io.openshift.release.operator="true"
 LABEL io.k8s.display-name="OpenShift ExternalDNS Operator" \

--- a/README.md
+++ b/README.md
@@ -26,3 +26,56 @@ This Operator is in the early stages of implementation. For the time being, plea
         *Note*: other provider options can be found in `api/v1alpha1/externaldns_types.go`, e.g. the `ExternalDNSAWSProviderOptions` structure for AWS.
     * Run `kubectl apply -k config/samples/aws` for AWS    
         *Note*: other providers available in `config/samples/`
+
+### OperatorHub install with custom index image
+
+This process refers to building the operator in a way that it can be installed locally via the OperatorHub with a custom index image.
+
+1. Build and push the bundle image to a registry:
+   ```sh
+   $ export BUNDLE_IMG=<registry>/<username>/external-dns-operator-bundle:latest
+   $ make bundle-image-build
+   $ make bundle-image-push
+   ```
+
+2. Build and push the image index for operator-registry:
+   ```sh
+   $ export INDEX_IMG=<registry>/<username>/external-dns-operator-bundle-index:1.0.0
+   $ make index-image-build
+   $ make index-image-push
+   ```
+
+3. Create the catalogsource (registry secret may need to be linked to the external-dns-operator's pod created in `openshift-marketplace`):
+   ```yaml
+   $ cat <<EOF | oc apply -f -
+   apiVersion: operators.coreos.com/v1alpha1
+   kind: CatalogSource
+   metadata:
+     name: external-dns-operator
+     namespace: openshift-marketplace
+   spec:
+     sourceType: grpc
+     image: <registry>/<username>/external-dns-operator-bundle-index:1.0.0
+   EOF
+   ```
+
+4. Create `external-dns-operator` namespace:
+   ```sh
+   $ oc create ns external-dns-operator
+   ```
+5. Create a subscription to install the operator:
+    ```yaml
+    cat <<EOF | oc apply -f -
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: external-dns-operator
+      namespace: external-dns-operator
+    spec:
+      channel: alpha
+      name: external-dns-operator
+      source: external-dns-operator
+      sourceNamespace: openshift-marketplace
+    EOF
+    ```
+    **Note**: Same thing can be done via the console: `Operators` -> `OperatorHub`, search for `ExternalDNS operator` and install the operator.

--- a/bundle/manifests/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns-operator-auth-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/bundle/manifests/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-operator-auth-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns-operator-auth-proxy
+subjects:
+- kind: ServiceAccount
+  name: external-dns-operator
+  namespace: external-dns-operator

--- a/bundle/manifests/external-dns-operator-auth-proxy_v1_service.yaml
+++ b/bundle/manifests/external-dns-operator-auth-proxy_v1_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: external-dns-operator
+  name: external-dns-operator-metrics-service
+  namespace: external-dns-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    name: external-dns-operator

--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -1,0 +1,121 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "externaldns.olm.openshift.io/v1alpha1",
+          "kind": "ExternalDNS",
+          "metadata": {
+            "name": "sample"
+          },
+          "spec": {
+            "provider": {
+              "type": "AWS",
+              "aws":
+                "credentials": {
+                  "name": "aws-access-key"
+                }
+            },
+            "source": {
+              "type": "Service"
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    olm.skipRange: ">=4.6.0 <4.10.0"
+    certified: "false"
+    repository: https://github.com/openshift/external-dns-operator
+    support: Red Hat, Inc.
+    createdAt: 2021/09/28
+    containerImage: quay.io/openshift/origin-external-dns-operator:latest
+  name: external-dns-operator.v0.0.1
+  namespace: external-dns-operator
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: ExternalDNS describes a managed ExternalDNS controller instance
+        for a cluster. The controller is responsible for creating external DNS records
+        in supported DNS providers based off of instances of select Kubernetes resources.
+      displayName: External DNS
+      kind: ExternalDNS
+      name: externaldnses.externaldns.olm.openshift.io
+      version: v1alpha1
+  description: ExternalDNS Operator deploys and manages ExternalDNS, which dynamically manages external DNS records in specific DNS Providers for specific Kubernetes resources.
+  displayName: ExternalDNS Operator
+  icon:
+  - base64data: 'iVBORw0KGgoAAAANSUhEUgAAAG4AAAB1CAMAAACYlCSRAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAMAUExURQAAAChbgRdOdyhbgStdgx5TeyhbgShbgShbgShbgSJXfiBVfCVZgChbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgShbgf/////+/itdg/z9/vz9/Shbgf3+/ilcghpQeSpdgrrh5P7+/+pwb7ng4xhPeFV9nJavwulxcP7///v8/Nbb3RxSevb5+vr7++Xo6urs7cbN0bnBxqeyt63T17a/w6Ots56qsPL09exycOPm6Jmoruzu8PP29+jq7F+Jlv38/IOlrkVxkjtqjbO7wLLY3GR3gcHIzPb3+Iqkq9DV2NLX2rzEyMrZ4LXc36jO0/W7uu/x8vfKyl+NnZyssyRYf/Dz9XeYsNne4I+jqrvj5q23vdrl6vOtrI+utZKzucXLz1mFlLXH1OyFhPGkpPbCwuvx9O+Tk6qzuaXLz2CGok13l22Omex/fp3DyJGqsMnP0/719YWTmnSEjaHGy+Do7ZW5vzVliVyJmNzg4pm+xHaVn+t6ef75+ulvbsXU26S6v+Dk5svR1Pvg4ISgqV+Gk2aLl25xfIqgqKK+xFppc3uep9pra6/FzZu7wm6Rq6m9zYipsYSht5ajqvCene6KieJtbYmutn+apJ6yuF1we3+hqneZo6SwtnB+h2+TnarAxLxoaubs8WaLpo6pve2OjoqDiWl7hZGfpolob9NpatXh54CdpXWquzpMWfr+/mCAjJG2vFh+jJStwSpdgi5fhYmlurrL177O2e+ZmKG3yH2cs46aodHe5IKPl7HO0mmaqndveUxxf0JcaLBna+Xw8vS0tNzq7ImXnnFpc5NxdlmAnnqJkVJ7ms7T1qu1urXU2H1qc3iRmsdnaWiFj6hlaTFih520xr3f4pNfZXRhafjPz4N3fvzp6JCOlIqzv1BeabzY32RZYaWLj5hla0tqd/vm5b3R1093hfra2dR2d6mts7iOktWGiNyLi0pBwGYAAAAodFJOUwBZ/vz9/akBAwT9/v0OiJcgFsQHKtlho/dK0PHhueg0dH1B7Tuxa1LrZH0hAAAOuElEQVRo3u1bd1xT2baOk2QIBAULOPaOe0LKSQQcTEICJCEhoQw1AemggLSAFFFAmiigICJIERSxoqCOdWxXnZ+99zKKfeZO7+XOve+9fU6CE5QUkvj+uuufnNTvrLW+tc7Ze33B4f5r/cyCZIkZycLi3WNZamJYkt4pGAnFsh3jMMzGZtjkmaMs34Q3r2fwl0dNGTGOwaSgxsDb2Uy1hLF9RymzwE2fgWdQaGQu4vIewiXPo1BoY+0tVT6bP46279OYTDLCCNyXuOnspQ2Pl3OJeAg4BjsT84KRcEOHfcAgELlLvkylApXlZu1jIBBwxijzAsL0WAwZzyBYIZ+fZ0McOpXNpjoCMAekJs7jEhgfDBtqvhSiZz5pBI1i7RLYRoVQdLVz6OEccGUx14rAGG9vYaYUwl8ZboNnEpAz+32BY18g1YY+zwp0sSbQRkw3R0RhjEZOnsYgkMkblkF3wFvm6AjcPjuD4Jn40bamRhQ93zF2NII1sqQWzPo7jP0MvrxsA5lIYIybPBLllClgo2bQKHhk+UY2cBwYTJVDEPkYsSLQ7GbijE4h/B5Gfq71ptwB46gB6AioG4PQophgZFGg5LefiJJ/8VEINgfoNpjC+Wet0aKwGT74FGIdawRMmkvgOSw7em0O/FDqPi6ZwJjoMNi+hnas0TQmHjnzkRt64gYZjCg4jxXF2KmDiShk18gp42DHIicu05O0tyKq+HI5msL3DS4K9GMzIfmtkNmRmj3EIIMf/yRxHloUU4YaUhQY+Seg5A/aSAeDBFMXxZXPYV+jjR+ivyiga8NtUPLTNs03OGlvpZDehhXFiEl6IgrJ74CSn7sv1QDy60ih734ml8DEw6LQ4aAlbpSK/OeBEXF8o6/tI6JFMUQrHnTcHsYR+eJLNyPjqJlCAGqXoEVhA+9mtERyCnSNmPjJoMivI6K8i2eIBNqEoQPikXDDaATy8vMQbBYwh8Hr/bLPXeCVcCA8Es6BRuAGLgNsOjCTzaKCVYkIgTbD4q37bRJuKp5CXCIBWuNIZ2vPlI6IboJ4w3Bv1AO81tgxrYJ8tKMBnsj39bHCU5D09ztzk3QV4QaIN/UNPDRxeFok0MURTyW9D1Du2f5cos4QTyF210FRsGoJmTl2ZL/0wQvAOAqyH7B1pSJWLEmJVR0m/HC8Uao69OD0BuskDIi0xtMc+rkHnWNYBfoCXZT0cRet8fBUw10/fpKPHUnE7mK+H1Un3iWEMpak4R7M3HgKclFnKIFU4Cf2EavcC/7tZqgCO1JGzA2uS9H1RXjVpVjTxmi4R8KNYVgvzwU6S4AqSBLNrVTBrbl14pEq8L0+Av4Tju6CB/u4FJt+cDYUJBHo6SWVwZI+Tiz6z4sHfDVhK/kCtu5yB+eITLt+ZBnL5Gbpg6OqPHPvFQlKDx48JEuRV2IBlfjo6Z8gd/k8/KjXcPCufByNsQwY0E4UvYKE1flPo9rThSHRzekyEd+Qfg1mE5lD4PWmD24SY17QfG1wsXKO2m9eccLqpyyWs3N0cnA6y5nFCmlemuLXdyaVPlqTt4FLmfIaDmUKeYkjGPhyqvDa2ZiARU3avaM5xBm1kLDkUyzsqDwjTI6lrq4pxUuqLXlnEcgVy9dX1ZkM8mMtaMBd8NPx053Q817ZtXRxWBSLFRVdnhFQlR8C3auQNeWnd8MGIy24Ht3hOfAvsMFn71FGa8ANYRJna4slb9Gu4/EnOjnKHT85h4m2C8sDCvwzV6xY4d+461RIxpOmfFa7jD+358/j1xuTtMF99B7lfQPhgKT75K0TX7Xs+KezszA9YHdm5snQG8+e3Vh3csWKxoD0qihnVlHZLy0nbr70oJsDDoCk0l/2Xv4nmrOAhsx1v+5dv7WmZuv6F69uNKwoKIcvs9of7v1RrJWkg4UD7t8fRNGEuzNDf13v7e2Kmbf31tvr4htOoXhLf/639m8PGo4quBYF0QoyH7xwcnWqccIMPngf+dS/IcPZOUq4K8mMcJwd6U1FUbszn/21pXBl4ZaFqBVuWVm4sND1K/+GqpCwpowEtulwPu48FTmvNSl3dmQ+OJIWszkuO+duXFpcTkzO3Zy4mANbP41vrBAHb+tQ9Wm6gm4cHN2XDTjdXsHzYXNezco41tEQ+sLpbkxe/YE0CPlNXEx2Ttw3OZu916+Lb00/Fl2+gw7olSIvERu8WcEGwfFEXsG9Ur862FBE12B6WjN/dXXKS8vOzjuwMDs7e/OFAxcubM5OW+l9u8E/H76/1h2we8OlfE5EirsxwWT7cCIEXrCYFAJIy+iG0CPeTtn139XHrCyMq/+9Ps21MO73378pdNr6LD4ANtBtHjD4Ii+v4DV8tnG546+p8/OZBepWw19Lz/zUybUm5sOcuI/vLiypv/uvVXlpIC4mptDJ+5V/AWyl5d0QLsmP72c0VXzki7ph2+1tg+141+nb3hBu1ZaV3/1rS0lOzYWP09I+zCmsgfV35BAaTWEyD/AivLzW0E0oBAWkZsQ1eKlphLFE4Q5419cfgHB5H6etjFv1XTas9603VlQsYEWtjQVsaSzV5LoTPS0vF/qvW++Keeddj3kH4WpcN39XcqDG1enT+G3CCuFaP/OUuai5U5bhv24rBrc5uyRnodq7vC1xH+ZhcDvDnoTtlJoLTtbZoYK7u6qkpH7LwpIYFO5CSUnJNyudVHCCVnPBeT4tqojGgulaeGHzhUIn1//968VfBwpX5m3Og2goXIewInqtuzng6L33r7EWRDV27d3q5O1UU1Ozfu/D7w8fvvrtq/XwCSRmzZEHmRULFkRVc0yFk0QkXy37+us9LGHFyZdXDz7cu97Je+/BsvxTFae2RT8/eNsJYt1+ePD5yV1VIcKe72UCTw7PeDi2LP76zVtff/Vo57EdtXfcciN3fP/w1TNlclF19cuT0WHFB1+9eli6+kqu250/Mo7t/vrbW7/d3J6iMBpOkvxT4q57kW17Iu+4YS/84w58In7enl9eVFRVcHjPnrZUtznqd2r3tF2517H6idRoOKpoUcGxf2DkFKiue5exG8AnyWFNTQnhaO/n+Pb7xurTTRLjc8erky/FkiG7XDzXw89D3tJdpxCJJMpOpUDAVwQH+4Qe5hcL+FJBsRruMN8kZkpVcOKWsvBQ5aHgltJHXl1d3T33PVvKSru7urxCL0d0Hbp6uUuuhlMCs8CdKJOGikKDe5ShV1uuBvf0cno8y0rh0aHwiFul4uKeUhUjm80DlyK7H3w4tEzZFbqo99Cj8PucylLlZY9DjzidoRGPyjyD++D2mAyHUYXn5pt6pdaH6gPXxbF+vNx7R1MVChDL5/Hgk9rI1Dp1ue3xMA2Ovz0V1oDbvay1uwt2B7TdY6NP2rb33Ojp+OMO/Ibv0ebW3QWN6X/cgafle2VnsWlwCkH19ub2gO0JXk0hwordf+5qb68+/edvDx603Dx9OqA5o+B0a5VwW6nn0u3pzRnH1vZtTRjdMyWdKQldclhM8qUhCzpSyloDqhv8/dElSUNBQMBL8eF8521NcGVXd79bdt/d5BYt4VeKOVJ0pbhmbXm61/YQdMFVlNFRlS90Zi2okh2r2pkAT0YR2yuWcvxMhqN7iKXFMuy065JbT0Wrl5Od7arlZFFrdQRKE58ETqUs3OQLkCJ4UaxcoM7Iop+/DciH60mWMFkUAB+chT+U3Xiies9PrHT38nQzCG4mk/h44C0jvgebLlWznH75q//5tmntNhjHUzuLoou2tVb/uPcX2etdAp6bJ8eA1atqba5/B0F560RLBM+vOEUWFhbWlLzDM0ny759P/Njbbxk+4Np8v4vG2pyEm86wClQAPZu0Pi/jMw+pHGXzFDws9rzQm9efx+rbtkV3xYZpbHTYfmB95hN9+yoR8cevJ7z54uH447vkevdVFhOZ9hpwI+0Y5FqgZ3ddEPBUfTvC5rF5PNVCINz/h9oUPXvEQBFkxZj+96YYCfc+BTmrb5MqqXORSIWRVMwJ71UtV3kJ1eK5evbcQeQ8xkSN/W9LnD1MHg/oGYvEStVLm17PYqVcXWS8JL7e1G1CKDP67WfajmMSzwFDxwe9nh5yebihEwwwH8bSXnO7FkaTSVwMDN3Sr+z1kM+tNHScAL5EKBOHa+4vknBTaUxilqHuUalKOZVqqHO50Lk3tvYtcDMYVkESg/1TyoHBziUilGm2/QclFrhR4yhcGE4D8ZI4BqKxwUUugTb5zbkFCTeZRnC5pGMY/9ZY1wCbwwZZZDxjwttDIAvcaBoBSfwQmGG6pSHAyJpnzRhvOxDcyBHQv8USdDJlFkPHcp9x8Yxxk3ADjEQtcEMn0AjcoCwTJ5OaY/vFCJ4xbTpuwAEs9A/G04q72JS5q8ZsS3KWRiTQ7EbhSFqFWQ6qqXKuoVzQziTHjUEueApt9FAcSccY21Y9M6caylFtgpLZmKBkDE6nMk8th7FCHtcOWhEwgDJgpL5BfZ/Yh6hN7GPI0PyjLxA8k2aYGAiVMo1GpUyUz3wHPdBGU35ucFIntVCLgHcJzBqc7AEl/1FMyDXRnmS4ZkUlQ0NT+PnRQcy1IbnmbzJKpvZaZDfvUq6BKYRxZG9cbqzeCBXkqFRUF3kGpBCNQe0SxBojvzFqKkwjNhbTiJ3XqhHT1FRsIJPVWjHjpFsw/JYOqAKOqKcoUNHP/jMIgYkfPdwUJVyfvo9L2a9dLQNPhK7W+U0yUefXp17EuwS10Qfsa2iYryxGUBXjEDOoGNHYqItiIKUTfCH3EtqxUPKTzKHRRItCreNCpSyO/Xsx7yJG/hm25hOEqnW1eOQL2NfmzKJSqY6OVCqqNHE8F4gMWodmUAqnYkURdDb173jmblyCquymOZhdPQwjRXKYyKBYI7TZmy6ei4w8v3H/vi8QMpOBtxn+LrTRmH5yGiqLRhAiNK4L0ZrCwJtbNtwvosMdRnzAoFCYDFT5zWTYDXtXYH1FgbO1t5kw1m683YjRkyeNxJmH/PoE+33Jsnzn/xGwsFRhwEfSu/9DQt894v8Xkkn2f1t20PFmJc7vAAAAAElFTkSuQmCC'
+    mediatype: "image/png"
+  install:
+    spec:
+      deployments:
+      - name: external-dns-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: external-dns-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: external-dns-operator
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: quay.io/openshift/origin-kube-rbac-proxy:latest
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+              - args:
+                - --metrics-bind-address=127.0.0.1:8080
+                env:
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: quay.io/openshift/origin-external-dns-operator:latest
+                name: operator
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 30Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: external-dns-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - openshift
+  - dns
+  - externaldns
+  - operator
+  links:
+  - name: Source code
+    url: https://github.com/openshift/external-dns-operator
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  version: 0.0.1

--- a/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,89 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: external-dns-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - externaldns.olm.openshift.io
+  resources:
+  - externaldnses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - externaldns.olm.openshift.io
+  resources:
+  - externaldnses/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - externaldns.olm.openshift.io
+  resources:
+  - externaldnses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns-operator
+subjects:
+- kind: ServiceAccount
+  name: external-dns-operator
+  namespace: external-dns-operator

--- a/bundle/manifests/external-dns-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/external-dns-operator_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns-operator
+  namespace: external-dns-operator

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -1,0 +1,506 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
+  creationTimestamp: null
+  name: externaldnses.externaldns.olm.openshift.io
+spec:
+  group: externaldns.olm.openshift.io
+  names:
+    kind: ExternalDNS
+    listKind: ExternalDNSList
+    plural: externaldnses
+    singular: externaldns
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExternalDNS describes a managed ExternalDNS controller instance
+          for a cluster. The controller is responsible for creating external DNS records
+          in supported DNS providers based off of instances of select Kubernetes resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              ExternalDNS.
+            properties:
+              domains:
+                description: "Domains specifies which domains that ExternalDNS should
+                  create DNS records for. Multiple domain values can be specified
+                  such that subdomains of an included domain can effectively be ignored
+                  using the \"Include\" and \"Exclude\" domain filter options. \n
+                  An empty list of domains means ExternalDNS will create DNS records
+                  for any included source resource regardless of the resource's desired
+                  hostname. \n Populating Domains with only excluded options means
+                  ExternalDNS will create DNS records for any included source resource
+                  that do not match the provided excluded domain options. \n Excluding
+                  DNS records that were previous included via a resource update will
+                  *not* result in the original DNS records being deleted."
+                items:
+                  description: ExternalDNSDomain describes how sets of included or
+                    excluded domains are to be constructed.
+                  properties:
+                    filterType:
+                      description: "FilterType marks the Name or Pattern field as
+                        an included or excluded set of domains. \n In the event of
+                        contradicting domain options, preference is given to excluded
+                        domains. \n This field accepts the following values: \n  \"Include\":
+                        Include the domain set specified  by name or pattern. \n  \"Exclude\":
+                        Exclude the domain set specified  by name or pattern."
+                      enum:
+                      - Include
+                      - Exclude
+                      type: string
+                    matchType:
+                      description: "MatchType specifies the type of match to be performed
+                        by ExternalDNS when determining whether or not to publish
+                        DNS records for a given source resource based on the resource's
+                        requested hostname. \n This field accepts the following values:
+                        \n  \"Exact\": Explicitly match the full domain string   specified
+                        via the Name field, including any subdomains   of Name. \n
+                        \ \"Pattern\": Match potential domains against  the provided
+                        regular expression pattern string."
+                      enum:
+                      - Exact
+                      - Pattern
+                      type: string
+                    names:
+                      description: "Name is a string representing a single domain
+                        value. Subdomains are included. \n e.g. my-app.my-cluster-domain.com
+                        would also include foo.my-app.my-cluster-domain.com"
+                      type: string
+                    pattern:
+                      description: Pattern is a regular expression used to match a
+                        set of domains. Any provided regular expressions should follow
+                        the syntax used by the go regexp package (RE2). See https://golang.org/pkg/regexp/
+                        for more information.
+                      type: string
+                  required:
+                  - filterType
+                  - matchType
+                  type: object
+                type: array
+              provider:
+                description: Provider refers to the DNS provider that ExternalDNS
+                  should publish records to. Note that each ExternalDNS is tied to
+                  a single provider.
+                properties:
+                  aws:
+                    description: AWS describes provider configuration options specific
+                      to AWS (Route 53).
+                    properties:
+                      credentials:
+                        description: "Credentials is a reference to a secret containing
+                          the following keys (with corresponding values): \n * aws_access_key_id
+                          * aws_secret_access_key \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md
+                          for more information."
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - credentials
+                    type: object
+                  azure:
+                    description: Azure describes provider configuration options specific
+                      to Azure DNS.
+                    properties:
+                      configFile:
+                        description: "ConfigFile is a reference to a secret containing
+                          the necessary information to use the Azure provider. The
+                          secret referenced by ConfigFile should contain a key named
+                          `azure.json` similar to the following: \n {   \"tenantId\":
+                          \"123\",   \"subscriptionId\": \"456\",   \"resourceGroup\":
+                          \"MyDnsResourceGroup\",   \"aadClientId\": \"789\",   \"aadClientSecret\":
+                          \"123\" } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md
+                          for more information on the necessary configuration key/values
+                          and how to obtain them."
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - configFile
+                    type: object
+                  blueCat:
+                    description: BlueCat describes provider configuration options
+                      specific to BlueCat DNS.
+                    properties:
+                      configFile:
+                        description: "ConfigFile is a reference to a secret containing
+                          the necessary information to use the BlueCat provider. The
+                          secret referenced by ConfigFile should contain an object
+                          named `bluecat.json` similar to the following: \n {   \"gatewayHost\":
+                          \"https://bluecatgw.example.com\",   \"gatewayUsername\":
+                          \"user\",   \"gatewayPassword\": \"pass\",   \"dnsConfiguration\":
+                          \"Example\",   \"dnsView\": \"Internal\",   \"rootZone\":
+                          \"example.com\",   \"skipTLSVerify\": false } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/bluecat.md
+                          for more information on the necessary configuration values
+                          and how to obtain them."
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - configFile
+                    type: object
+                  gcp:
+                    description: GCP describes provider configuration options specific
+                      to GCP (Google DNS).
+                    properties:
+                      credentials:
+                        description: Credentials is a reference to a secret containing
+                          the necessary GCP service account keys. The secret referenced
+                          by Credentials should contain a key named `service_account.json`
+                          presumably generated by the gcloud CLI.
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      project:
+                        description: Project is the GCP project to use for creating
+                          DNS records. This field is not necessary when running on
+                          GCP as externalDNS auto-detects the GCP project to use when
+                          running on GCP.
+                        type: string
+                    required:
+                    - credentials
+                    type: object
+                  infoblox:
+                    description: Infoblox describes provider configuration options
+                      specific to Infoblox DNS.
+                    properties:
+                      credentials:
+                        description: "Credentials is a reference to a secret containing
+                          the following keys (with proper corresponding values): \n
+                          * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+                          \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/infoblox.md
+                          for more information and configuration options."
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      gridHost:
+                        default: 127.0.0.1
+                        description: "GridHost is the IP of the Infoblox Grid host.
+                          \n kubebuilder:validation:Required"
+                        type: string
+                      wapiPort:
+                        default: 443
+                        description: "WAPIPort is the port for the Infoblox WAPI.
+                          \n kubebuilder:validation:Required"
+                        type: integer
+                      wapiVersion:
+                        default: 2.3.1
+                        description: "WAPIVersion is the version of the Infoblox WAPI.
+                          \n kubebuilder:validation:Required"
+                        type: string
+                    required:
+                    - credentials
+                    - gridHost
+                    - wapiPort
+                    - wapiVersion
+                    type: object
+                  type:
+                    description: "Type describes which DNS provider ExternalDNS should
+                      publish records to. The following DNS providers are supported:
+                      \n  * AWS (Route 53)  * GCP (Google DNS)  * Azure  * BlueCat
+                      \ * Infoblox"
+                    enum:
+                    - AWS
+                    - GCP
+                    - Azure
+                    - BlueCat
+                    - Infoblox
+                    type: string
+                required:
+                - type
+                type: object
+              source:
+                description: "Source describes which source resource ExternalDNS will
+                  be configured to create DNS records for. \n Multiple ExternalDNS
+                  CRs must be created if multiple ExternalDNS source resources are
+                  desired."
+                properties:
+                  annotationFilter:
+                    additionalProperties:
+                      type: string
+                    description: AnnotationFilter describes an annotation filter used
+                      to filter which source instance resources ExternalDNS publishes
+                      records for. The annotation filter uses label selector semantics
+                      against source resource annotations.
+                    type: object
+                  crd:
+                    description: CRD describes source configuration options specific
+                      to the CRD source resource. See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/contributing/crd-source.md
+                      for more information about the requirements for ExternalDNS
+                      Source CRD requirements.
+                    properties:
+                      kind:
+                        description: "Kind is the kind of the CRD source resource
+                          type to be consumed by ExternalDNS. \n e.g. \"DNSEndpoint\""
+                        minLength: 1
+                        type: string
+                      labelFilter:
+                        description: LabelFilter specifies a label filter to be used
+                          to filter CRD resource instances. Only one label filter
+                          can be specified on an ExternalDNS instance.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      version:
+                        description: "Version is the API version of the given resource
+                          kind for ExternalDNS to use. \n e.g. \"externaldns.k8s.io/v1alpha1\""
+                        minLength: 1
+                        type: string
+                    required:
+                    - kind
+                    - version
+                    type: object
+                  fqdnTemplate:
+                    description: "FQDNTemplate sets a templated string that's used
+                      to generate DNS names from sources that don't define a hostname
+                      themselves. Multiple global FQDN templates are possible. \n
+                      Should not be empty when HostnameAnnotationPolicy is set to
+                      Ignore. \n Provided templates should follow the syntax defined
+                      for text/template Go package, see https://pkg.go.dev/text/template.
+                      Annotations inside the template correspond to the definition
+                      of the source resource object (e.g. Kubernetes service, OpenShift
+                      route). Example: \"{{.Name}}.example.com\" would be expanded
+                      to \"myservice.example.com\" for service source"
+                    items:
+                      type: string
+                    type: array
+                  hostnameAnnotation:
+                    default: Ignore
+                    description: "HostnameAnnotationPolicy specifies whether or not
+                      ExternalDNS should ignore the \"external-dns.alpha.kubernetes.io/hostname\"
+                      annotation, which overrides DNS hostnames on a given source
+                      resource. \n The following values are accepted: \n  \"Ignore\":
+                      Ignore any hostname annotation overrides.  \"Allow\": Allow
+                      all hostname annotation overrides. \n The default behavior of
+                      the ExternalDNS is \"Ignore\". \n Note that by setting a HostnameAnnotationPolicy
+                      of \"Allow\", may grant privileged DNS permissions to under-privileged
+                      cluster users."
+                    enum:
+                    - Ignore
+                    - Allow
+                    type: string
+                  namespace:
+                    description: Namespace instructs ExternalDNS to only acknowledge
+                      source resource instances in a specific namespace.
+                    type: string
+                  service:
+                    description: Service describes source configuration options specific
+                      to the service source resource.
+                    properties:
+                      serviceType:
+                        default:
+                        - LoadBalancer
+                        description: "ServiceType determines what types of Service
+                          resources are watched by ExternalDNS. The following types
+                          are available options: \n  \"NodePort\"  \"ExternalName\"
+                          \ \"LoadBalancer\"  \"ClusterIP\" \n One or more Service
+                          types can be specified, if desired. \n Note that using the
+                          \"ClusterIP\" service type will enable the ExternalDNS \"--publish-internal-services\"
+                          flag, which allows ExternalDNS to publish DNS records for
+                          ClusterIP services. \n If no service types are provided,
+                          ExternalDNS will be configured to create DNS records for
+                          LoadBalancer services only by default."
+                        items:
+                          description: Service Type string describes ingress methods
+                            for a service
+                          type: string
+                        minItems: 1
+                        type: array
+                    type: object
+                  type:
+                    description: Type specifies an ExternalDNS source resource to
+                      create DNS records for.
+                    enum:
+                    - OpenShiftRoute
+                    - Service
+                    - CRD
+                    type: string
+                required:
+                - hostnameAnnotation
+                - type
+                type: object
+              zones:
+                description: "Zones describes which DNS Zone IDs ExternalDNS should
+                  publish records to. \n Updating this field after creation will cause
+                  all DNS records in the previous zone(s) to be left behind."
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+            required:
+            - provider
+            - source
+            type: object
+          status:
+            description: status is the most recently observed status of the ExternalDNS.
+            properties:
+              conditions:
+                description: Conditions is a list of operator-specific conditions
+                  and their status.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
+              zones:
+                description: Zones is the configured zones in use by ExternalDNS.
+                items:
+                  type: string
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "external-dns-operator"
+  operators.operatorframework.io.bundle.channels.v1: "alpha"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"


### PR DESCRIPTION
This PR adds `manifests/` and `metadata/` directories which contain the files to be present in OLM bundle for ExternalDNS Operator.
The PR adds some README instructions on how to install the bundle on the cluster. These instructions were tested manually:
```bash
$ oc -n openshift-marketplace get catalogsource external-dns-operator
NAME                    DISPLAY   TYPE   PUBLISHER   AGE
external-dns-operator             grpc               7m47s

$ oc -n openshift-marketplace get pods | grep external-dns-operator
external-dns-operator-jrkzc                                       1/1     Running     0          7m55s

$ oc -n external-dns-operator get csv,sub,pods
NAME                                                                      DISPLAY                VERSION   REPLACES   PHASE
clusterserviceversion.operators.coreos.com/external-dns-operator.v0.0.1   ExternalDNS Operator   0.0.1                Succeeded

NAME                                                      PACKAGE                 SOURCE                  CHANNEL
subscription.operators.coreos.com/external-dns-operator   external-dns-operator   external-dns-operator   alpha

NAME                                         READY   STATUS    RESTARTS   AGE
pod/external-dns-operator-796bcbfbd6-b4p7j   2/2     Running   0          6m47s
```

The contents of `manifests/` directory is the same as the rendered version of Kustomize files in `config/default/`.