### PR TITLE
Begin implementing ExternalDNS Deployment logic

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - externaldns.olm.openshift.io
   resources:
   - externaldnses

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/google/go-cmp v0.5.6
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1

--- a/pkg/operator/controller/externaldns/deployment.go
+++ b/pkg/operator/controller/externaldns/deployment.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+// providerStringTable maps ExternalDNSProviderType values from the
+// ExternalDNS operator API and converts them to the provider
+// string argument expected by ExternalDNS.
+var providerStringTable = map[operatorv1alpha1.ExternalDNSProviderType]string{
+	operatorv1alpha1.ProviderTypeAWS:      "aws",
+	operatorv1alpha1.ProviderTypeGCP:      "google",
+	operatorv1alpha1.ProviderTypeAzure:    "azure",
+	operatorv1alpha1.ProviderTypeBlueCat:  "bluecat",
+	operatorv1alpha1.ProviderTypeInfoblox: "infoblox",
+}
+
+// sourceStringTable maps ExternalDNSSourceType values from the
+// ExternalDNS operatoor API and converts them to the source
+// string arugment expected by ExternalDNS.
+var sourceStringTable = map[operatorv1alpha1.ExternalDNSSourceType]string{
+	operatorv1alpha1.SourceTypeRoute:   "openshift-route",
+	operatorv1alpha1.SourceTypeService: "service",
+	// TODO: Add CRD source support
+}
+
+// ensureExternalDNSDeployment ensures that the externalDNS deployment exists.
+func (r *reconciler) ensureExternalDNSDeployment(ctx context.Context, namespace string, image string, serviceAccount *corev1.ServiceAccount, externalDNS *operatorv1alpha1.ExternalDNS) (bool, *appsv1.Deployment, error) {
+	desired, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to build externalDNS deployment: %w", err)
+	}
+
+	haveDepl, current, err := r.currentExternalDNSDeployment(ctx, namespace, externalDNS)
+	if err != nil {
+		return haveDepl, current, fmt.Errorf("failed to get externalDNS deployment: %w", err)
+	}
+
+	switch {
+	case !haveDepl:
+		if err := r.createExternalDNSDeployment(ctx, desired); err != nil {
+			return false, nil, err
+		}
+		return r.currentExternalDNSDeployment(ctx, namespace, externalDNS)
+	case haveDepl:
+		if updated, err := r.updateExternalDNSDeployment(ctx, current, desired); err != nil {
+			return true, current, err
+		} else if updated {
+			return r.currentExternalDNSDeployment(ctx, namespace, externalDNS)
+		}
+	}
+
+	return false, current, nil
+}
+
+// currentExternalDNSDeployment gets the current externalDNS deployment resource.
+func (r *reconciler) currentExternalDNSDeployment(ctx context.Context, namespace string, externalDNS *operatorv1alpha1.ExternalDNS) (bool, *appsv1.Deployment, error) {
+	depl := &appsv1.Deployment{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: "externalDNS" + externalDNS.Name}, depl); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, depl, nil
+}
+
+// desiredExternalDNSDeployment returns the desired deployment resource.
+func desiredExternalDNSDeployment(namespace string, image string, serviceAccount *corev1.ServiceAccount, externalDNS *operatorv1alpha1.ExternalDNS) (*appsv1.Deployment, error) {
+	depl := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "externalDNS-" + externalDNS.Name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 { one := int32(1); return &one }(),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccount.Name,
+					NodeSelector: map[string]string{
+						"kubernetes.io/os":               "linux",
+						"node-role.kubernetes.io/master": "",
+					},
+				},
+			},
+		},
+	}
+
+	containers := []corev1.Container{}
+	port := 7979
+	for i, zone := range externalDNS.Spec.Zones {
+		container, err := populateExternalDNSContainer(image, port+i, zone, externalDNS)
+		if err != nil {
+			return depl, fmt.Errorf("failed to create ExternalDNS deployment %s/%s: %w", depl.Namespace, depl.Name, err)
+		}
+		containers = append(containers, *container)
+	}
+
+	depl.Spec.Template.Spec.Containers = containers
+
+	return depl, nil
+}
+
+// WIP function for generating container specs for one container at a time.
+func populateExternalDNSContainer(image string, metricsPort int, zone string, externalDNS *operatorv1alpha1.ExternalDNS) (*corev1.Container, error) {
+	name := "externaldns-" + zone
+
+	args := []string{
+		fmt.Sprintf("--metrics-address=127.0.0.1:%d", metricsPort),
+		fmt.Sprintf("--text-owner-id=externaldns-%s", externalDNS.Name),
+		"--policy=sync",
+		"--registry=txt",
+		"--log-level=debug",
+		fmt.Sprintf("--zone-id-filter=%s", zone),
+	}
+
+	provider, ok := providerStringTable[externalDNS.Spec.Provider.Type]
+	if !ok {
+		return nil, fmt.Errorf("failed to build ExternalDNS container: %s is not a supported provider", externalDNS.Spec.Provider.Type)
+	}
+
+	args = append(args, fmt.Sprintf("--provider=%s", provider))
+
+	//TODO: Add provider credentials logic
+
+	source, ok := sourceStringTable[externalDNS.Spec.Source.Type]
+	if !ok {
+		return nil, fmt.Errorf("failed to build ExternalDNS container: %s is not a supported source type", externalDNS.Spec.Source.Type)
+	}
+
+	args = append(args, fmt.Sprintf("--source=%s", source))
+
+	if externalDNS.Spec.Source.Namespace != nil && len(*externalDNS.Spec.Source.Namespace) > 0 {
+		args = append(args, fmt.Sprintf("--namespace=%s", *externalDNS.Spec.Source.Namespace))
+	}
+
+	if externalDNS.Spec.Source.Service != nil && len(externalDNS.Spec.Source.Service.ServiceType) > 0 {
+		var serviceTypeFilter string
+		publishInternal := false
+		for i, serviceType := range externalDNS.Spec.Source.Service.ServiceType {
+			serviceTypeFilter += string(serviceType)
+			// avoid having a trailing comma.
+			if i < len(externalDNS.Spec.Source.Service.ServiceType)-1 {
+				serviceTypeFilter += ","
+			}
+			if serviceType == corev1.ServiceTypeClusterIP {
+				publishInternal = true
+			}
+		}
+		args = append(args, fmt.Sprintf("--service-type-filter=%s", serviceTypeFilter))
+
+		if publishInternal {
+			args = append(args, "--publish-internal-services")
+		}
+	}
+
+	if externalDNS.Spec.Source.HostnameAnnotationPolicy == operatorv1alpha1.HostnameAnnotationPolicyIgnore {
+		args = append(args, fmt.Sprintf("--ignore-hostname-annotation"))
+	}
+
+	//TODO: Add logic for the CRD source.
+
+	return &corev1.Container{
+		Name:                     name,
+		Image:                    image,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Args:                     args,
+	}, nil
+
+}
+
+// createExternalDNSDeployment creates the given deployment using the reconciler's client.
+func (r *reconciler) createExternalDNSDeployment(ctx context.Context, depl *appsv1.Deployment) error {
+	if err := r.client.Create(ctx, depl); err != nil {
+		return fmt.Errorf("failed to create externalDNS deployment %s/%s: %w", depl.Namespace, depl.Name, err)
+	}
+	r.log.Info("created externalDNS deployment", "namespace", depl.Namespace, "name", depl.Name)
+	return nil
+}
+
+// updateExternalDNSDeployment updates the in-cluster externalDNS deployment.
+// Returns a boolean if an update was made, and an error when relevant.
+func (r *reconciler) updateExternalDNSDeployment(ctx context.Context, current, desired *appsv1.Deployment) (bool, error) {
+	changed, updated := externalDNSDeploymentChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, fmt.Errorf("failed to update externalDNS deployment %s/%s: %w", updated.Namespace, updated.Name, err)
+	}
+	r.log.Info("updated externalDNS daemonset", "namespace", updated.Namespace, "name", updated.Name)
+	return true, nil
+}
+
+// externalDNSDeploymentChange evaluates whether or not a deployment update is necessary.
+// Returns a boolean if an update is necessary, and the deployment resource to update to.
+func externalDNSDeploymentChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if len(current.Spec.Template.Spec.Containers) > 0 && len(expected.Spec.Template.Spec.Containers) > 0 {
+		if current.Spec.Template.Spec.Containers[0].Image != expected.Spec.Template.Spec.Containers[0].Image {
+			updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
+			changed = true
+		}
+		if !cmp.Equal(current.Spec.Template.Spec.Containers[0].Args, expected.Spec.Template.Spec.Containers[0].Args) {
+			updated.Spec.Template.Spec.Containers[0].Args = expected.Spec.Template.Spec.Containers[0].Args
+			changed = true
+		}
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	return true, updated
+}

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+const (
+	namespace = "externaldns"
+	name      = "test"
+	image     = "bitname/external-dns:latest"
+)
+
+func TestDesiredExternalDNSDeployment(t *testing.T) {
+	sourceNamespace := "my-namespace"
+	externalDNS := &operatorv1alpha1.ExternalDNS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: operatorv1alpha1.ExternalDNSSpec{
+			Provider: operatorv1alpha1.ExternalDNSProvider{
+				Type: operatorv1alpha1.ProviderTypeGCP,
+			},
+			Source: operatorv1alpha1.ExternalDNSSource{
+				ExternalDNSSourceUnion: operatorv1alpha1.ExternalDNSSourceUnion{
+					Type:      operatorv1alpha1.SourceTypeService,
+					Namespace: &sourceNamespace,
+					Service: &operatorv1alpha1.ExternalDNSServiceSourceOptions{
+						ServiceType: []corev1.ServiceType{
+							corev1.ServiceTypeNodePort,
+							corev1.ServiceTypeLoadBalancer,
+							corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+				HostnameAnnotationPolicy: operatorv1alpha1.HostnameAnnotationPolicyIgnore,
+			},
+			Zones: []string{
+				"my-dns-public-zone",
+				"my-dns-private-zone",
+			},
+		},
+	}
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	depl, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+
+	if err != nil {
+		t.Errorf("expected no error from calling desiredExternalDNSDeployment, but received %v", err)
+	}
+
+	if len(depl.Spec.Template.Spec.Containers) != len(externalDNS.Spec.Zones) {
+		t.Errorf("expected externalDNS deployment to have %d containers, but found %d", len(externalDNS.Spec.Zones), len(depl.Spec.Template.Spec.Containers))
+	}
+
+	port := 7979
+	expectedArgs := []string{
+		"--provider=google",
+		"--source=service",
+		"--service-type-filter=NodePort,LoadBalancer,ClusterIP",
+		"--publish-internal-services",
+		"--ignore-hostname-annotation",
+		fmt.Sprintf("--namespace=%s", sourceNamespace),
+	}
+
+	for i, container := range depl.Spec.Template.Spec.Containers {
+		expectedCustomArgs := append(expectedArgs, fmt.Sprintf("--metrics-address=127.0.0.1:%d", port+i))
+		expectedCustomArgs = append(expectedCustomArgs, fmt.Sprintf("--zone-id-filter=%s", externalDNS.Spec.Zones[i]))
+		argSliceString := strings.Join(container.Args, " ")
+		for _, arg := range expectedCustomArgs {
+			if !strings.Contains(argSliceString, arg) {
+				t.Errorf("expected externalDNS container %s to contain the following argument %q, but it did not. Found args: %v",
+					container.Name, arg, container.Args)
+			}
+		}
+	}
+}
+
+func TestExternalDNSDeploymentChanged(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*appsv1.Deployment)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *appsv1.Deployment) {},
+			expect:      false,
+		},
+		{
+			description: "if externalDNS image changes",
+			mutate: func(depl *appsv1.Deployment) {
+				depl.Spec.Template.Spec.Containers[0].Image = "foo.io/test:latest"
+			},
+			expect: true,
+		},
+		{
+			description: "if externalDNS container args",
+			mutate: func(depl *appsv1.Deployment) {
+				depl.Spec.Template.Spec.Containers[0].Args = []string{"Nada"}
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		externalDNS := &operatorv1alpha1.ExternalDNS{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: operatorv1alpha1.ExternalDNSSpec{
+				Provider: operatorv1alpha1.ExternalDNSProvider{
+					Type: operatorv1alpha1.ProviderTypeAWS,
+				},
+				Source: operatorv1alpha1.ExternalDNSSource{
+					ExternalDNSSourceUnion: operatorv1alpha1.ExternalDNSSourceUnion{
+						Type: operatorv1alpha1.SourceTypeRoute,
+					},
+				},
+				Zones: []string{"my-dns-zone"},
+			},
+		}
+
+		serviceAccount := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		original, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+		if err != nil {
+			t.Errorf("expected no error from calling desiredExternalDNSDeployment, but received %v", err)
+		}
+
+		mutated := original.DeepCopy()
+		tc.mutate(mutated)
+		if changed, updated := externalDNSDeploymentChanged(original, mutated); changed != tc.expect {
+			t.Errorf("%s, expect externalDNSDeploymentChanged to be %t, got %t", tc.description, tc.expect, changed)
+		} else if changed {
+			if changedAgain, _ := externalDNSDeploymentChanged(mutated, updated); changedAgain {
+				t.Errorf("%s, externalDNSDeploymentChanged does not behave as a fixed point function", tc.description)
+			}
+		}
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,7 @@ type Operator struct {
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts,verbs=get;list;watch;delete;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;delete;create;update
 
 // New creates a new operator from cliCfg and opCfg.
 func New(cliCfg *rest.Config, opCfg *operatorconfig.Config) (*Operator, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,6 +46,7 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.5.6
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
config/rbac/role.yaml:

Update operator RBAC for deployments.

go.mod & vendor/modules.txt:

Explicitly add go-cmp dep.

pkg/operator/controller/externaldns/controller.go:

Call deployment logic.

pkg/operator/controller/externaldns/deployment.go:

Add initial deployment logic.

pkg/operator/controller/externaldns/deployment_test.go:

Add initial deployment logic unit tests.

pkg/operator/operator.go:

Add deployment RBAC markers.