### PR TITLE
Begin implementing deployment logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ This Operator is in the early stages of implementation. For the time being, plea
    ```
 2. Make sure to uncomment the `image` in `config/manager/kustomization.yaml` and set it to the operator image you pushed
 3. Run `oc apply -k config/default`
+4. Now you can deploy an instance of ExternalDNS, run `oc apply -k config/samples`

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -38,7 +38,7 @@ type ExternalDNS struct {
 	// spec is the specification of the desired behavior of the ExternalDNS.
 	Spec ExternalDNSSpec `json:"spec"`
 	// status is the most recently observed status of the ExternalDNS.
-	Status ExternalDNSStatus `json:"status"`
+	Status ExternalDNSStatus `json:"status,omitempty"`
 }
 
 // ExternalDNSSpec defines the desired state of the ExternalDNS.
@@ -90,6 +90,7 @@ type ExternalDNSSpec struct {
 	// will cause all DNS records in the previous
 	// zone(s) to be left behind.
 	//
+	// +kubebuilder:validation:MaxItems=10
 	// +optional
 	Zones []string `json:"zones,omitempty"`
 }

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -410,6 +410,7 @@ spec:
                   all DNS records in the previous zone(s) to be left behind."
                 items:
                   type: string
+                maxItems: 10
                 type: array
             required:
             - provider
@@ -501,7 +502,6 @@ spec:
             type: object
         required:
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -22,6 +22,3 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-      - name: operator
-        args:
-        - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - name: operator
+      - name: external-dns-operator
         args:
         - "--config=controller_manager_config.yaml"
         volumeMounts:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - name: operator
+      - name: external-dns-operator
         image: quay.io/openshift/origin-external-dns-operator:latest
         args:
         - --operator-namespace=$(OPERATOR_NAMESPACE)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - externaldns.olm.openshift.io
   resources:
   - externaldnses

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,4 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- operator_v1alpha1_externaldns.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/operator_v1alpha1_externaldns.yaml
+++ b/config/samples/operator_v1alpha1_externaldns.yaml
@@ -1,5 +1,18 @@
 apiVersion: externaldns.olm.openshift.io/v1alpha1
 kind: ExternalDNS
 metadata:
-  name: externaldns-sample
+  name: sample
+  namespace: external-dns-operator
 spec:
+  provider:
+    type: AWS
+    aws:
+      credentials:
+        name: aws-access-key
+        namespace: external-dns-operator
+  source:
+    type: Service
+    namespace: "publish-external-dns"
+    annotationFilter:
+      external-dns.mydomain.org/publish: "yes"
+  zones: ["myzoneid"]

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/google/go-cmp v0.5.6
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -19,8 +19,8 @@ package config
 const (
 	DefaultExternalDNSImage  = "docker.io/bitnami/external-dns:latest"
 	DefaultMetricsAddr       = "127.0.0.1:8080"
-	DefaultOperatorNamespace = "externaldns-operator"
-	DefaultOperandNamespace  = "externaldns"
+	DefaultOperatorNamespace = "external-dns-operator"
+	DefaultOperandNamespace  = "external-dns"
 )
 
 // Config is configuration of the operator.

--- a/pkg/operator/controller/externaldns/deployment.go
+++ b/pkg/operator/controller/externaldns/deployment.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+	controller "github.com/openshift/external-dns-operator/pkg/operator/controller"
+)
+
+const (
+	metricsStartPort    = 7979
+	appNameLabel        = "app.kubernetes.io/name"
+	appInstanceLabel    = "app.kubernetes.io/instance"
+	masterNodeRoleLabel = "node-role.kubernetes.io/master"
+	osLabel             = "kubernetes.io/os"
+	linuxOS             = "linux"
+)
+
+// providerStringTable maps ExternalDNSProviderType values from the
+// ExternalDNS operator API to the provider string argument expected by ExternalDNS.
+var providerStringTable = map[operatorv1alpha1.ExternalDNSProviderType]string{
+	operatorv1alpha1.ProviderTypeAWS:      "aws",
+	operatorv1alpha1.ProviderTypeGCP:      "google",
+	operatorv1alpha1.ProviderTypeAzure:    "azure",
+	operatorv1alpha1.ProviderTypeBlueCat:  "bluecat",
+	operatorv1alpha1.ProviderTypeInfoblox: "infoblox",
+}
+
+// sourceStringTable maps ExternalDNSSourceType values from the
+// ExternalDNS operator API to the source string argument expected by ExternalDNS.
+var sourceStringTable = map[operatorv1alpha1.ExternalDNSSourceType]string{
+	operatorv1alpha1.SourceTypeRoute:   "openshift-route",
+	operatorv1alpha1.SourceTypeService: "service",
+	// TODO: Add CRD source support
+}
+
+// ensureExternalDNSDeployment ensures that the externalDNS deployment exists.
+// Returns a Boolean value indicating whether the deployment exists, a pointer to the deployment, and an error when relevant.
+func (r *reconciler) ensureExternalDNSDeployment(ctx context.Context, namespace, image string, serviceAccount *corev1.ServiceAccount, externalDNS *operatorv1alpha1.ExternalDNS) (bool, *appsv1.Deployment, error) {
+	nsName := types.NamespacedName{Namespace: namespace, Name: controller.ExternalDNSResourceName(externalDNS)}
+
+	desired, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to build externalDNS deployment: %w", err)
+	}
+
+	exist, current, err := r.currentExternalDNSDeployment(ctx, nsName)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get externalDNS deployment: %w", err)
+	}
+
+	// create the deployment
+	if !exist {
+		if err := r.createExternalDNSDeployment(ctx, desired); err != nil {
+			return false, nil, err
+		}
+		// get the deployment from API to catch up the fields added/updated by API and webhooks
+		return r.currentExternalDNSDeployment(ctx, nsName)
+	}
+
+	// update the deployment
+	if _, err := r.updateExternalDNSDeployment(ctx, current, desired); err != nil {
+		return true, current, err
+	}
+
+	// get the deployment from API to catch up the fields added/updated by API and webhooks
+	return r.currentExternalDNSDeployment(ctx, nsName)
+}
+
+// currentExternalDNSDeployment gets the current externalDNS deployment resource.
+func (r *reconciler) currentExternalDNSDeployment(ctx context.Context, nsName types.NamespacedName) (bool, *appsv1.Deployment, error) {
+	depl := &appsv1.Deployment{}
+	if err := r.client.Get(ctx, nsName, depl); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, depl, nil
+}
+
+// desiredExternalDNSDeployment returns the desired deployment resource.
+func desiredExternalDNSDeployment(namespace, image string, serviceAccount *corev1.ServiceAccount, externalDNS *operatorv1alpha1.ExternalDNS) (*appsv1.Deployment, error) {
+	replicas := int32(1)
+
+	matchLbl := map[string]string{
+		appNameLabel:     controller.ExternalDNSBaseName,
+		appInstanceLabel: externalDNS.Name,
+	}
+
+	nodeSelectorLbl := map[string]string{
+		osLabel:             linuxOS,
+		masterNodeRoleLabel: "",
+	}
+
+	depl := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.ExternalDNSResourceName(externalDNS),
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLbl,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: matchLbl,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccount.Name,
+					NodeSelector:       nodeSelectorLbl,
+				},
+			},
+		},
+	}
+
+	provider, ok := providerStringTable[externalDNS.Spec.Provider.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider: %q", externalDNS.Spec.Provider.Type)
+	}
+	source, ok := sourceStringTable[externalDNS.Spec.Source.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported source type: %q", externalDNS.Spec.Source.Type)
+	}
+
+	for i, zone := range externalDNS.Spec.Zones {
+		container, err := buildExternalDNSContainer(i, image, zone, provider, source, externalDNS)
+		if err != nil {
+			return nil, err
+		}
+		depl.Spec.Template.Spec.Containers = append(depl.Spec.Template.Spec.Containers, *container)
+	}
+
+	return depl, nil
+}
+
+// WIP function for generating container specs for one container at a time.
+func buildExternalDNSContainer(seq int, image, zone, provider, source string, externalDNS *operatorv1alpha1.ExternalDNS) (*corev1.Container, error) {
+	name := fmt.Sprintf("externaldns-%d", seq+1)
+
+	args := []string{
+		fmt.Sprintf("--metrics-address=127.0.0.1:%d", metricsStartPort+seq),
+		fmt.Sprintf("--txt-owner-id=externaldns-%s", externalDNS.Name),
+		fmt.Sprintf("--zone-id-filter=%s", zone),
+		fmt.Sprintf("--provider=%s", provider),
+		fmt.Sprintf("--source=%s", source),
+		"--policy=sync",
+		"--registry=txt",
+		"--log-level=debug",
+	}
+
+	//TODO: Add provider credentials logic
+
+	if externalDNS.Spec.Source.Namespace != nil && len(*externalDNS.Spec.Source.Namespace) > 0 {
+		args = append(args, fmt.Sprintf("--namespace=%s", *externalDNS.Spec.Source.Namespace))
+	}
+
+	if len(externalDNS.Spec.Source.AnnotationFilter) > 0 {
+		annotationFilter := ""
+		for key, value := range externalDNS.Spec.Source.AnnotationFilter {
+			annotationFilter += fmt.Sprintf("%s=%s,", key, value)
+		}
+		args = append(args, fmt.Sprintf("--annotation-filter=%s", annotationFilter[0:len(annotationFilter)-1]))
+	}
+
+	if externalDNS.Spec.Source.Service != nil && len(externalDNS.Spec.Source.Service.ServiceType) > 0 {
+		serviceTypeFilter, publishInternal := "", false
+		for _, serviceType := range externalDNS.Spec.Source.Service.ServiceType {
+			serviceTypeFilter += string(serviceType) + ","
+			if serviceType == corev1.ServiceTypeClusterIP {
+				publishInternal = true
+			}
+		}
+
+		// avoid having a trailing comma
+		args = append(args, fmt.Sprintf("--service-type-filter=%s", serviceTypeFilter[0:len(serviceTypeFilter)-1]))
+
+		if publishInternal {
+			args = append(args, "--publish-internal-services")
+		}
+	}
+
+	if externalDNS.Spec.Source.HostnameAnnotationPolicy == operatorv1alpha1.HostnameAnnotationPolicyIgnore {
+		args = append(args, "--ignore-hostname-annotation")
+	}
+
+	//TODO: Add logic for the CRD source.
+
+	return &corev1.Container{
+		Name:                     name,
+		Image:                    image,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Args:                     args,
+	}, nil
+}
+
+// createExternalDNSDeployment creates the given deployment using the reconciler's client.
+func (r *reconciler) createExternalDNSDeployment(ctx context.Context, depl *appsv1.Deployment) error {
+	if err := r.client.Create(ctx, depl); err != nil {
+		return fmt.Errorf("failed to create externalDNS deployment %s/%s: %w", depl.Namespace, depl.Name, err)
+	}
+	r.log.Info("created externalDNS deployment", "namespace", depl.Namespace, "name", depl.Name)
+	return nil
+}
+
+// updateExternalDNSDeployment updates the in-cluster externalDNS deployment.
+// Returns a boolean if an update was made, and an error when relevant.
+func (r *reconciler) updateExternalDNSDeployment(ctx context.Context, current, desired *appsv1.Deployment) (bool, error) {
+	// don't always update (or do simple DeepEqual with) the operand's deployment
+	// as this may result into a "fight" between API/admission webhooks and this controller
+	// example:
+	//  - this controller creates a deployment with the desired fields A, B, C
+	//  - API adds some default fields D, E, F (e.g. metadata, imagePullPullPolicy, dnsPolicy)
+	//  - mutating webhooks add default values to fields E, F
+	//  - this controller gets into reconcile loop and starts all from step 1
+	//  - checking that fields A, B, C are the same as desired would save us the before mentioned round trips:
+	changed, updated := externalDNSDeploymentChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, fmt.Errorf("failed to update externalDNS deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+	r.log.Info("updated externalDNS deployment", "namespace", desired.Namespace, "name", desired.Name)
+	return true, nil
+}
+
+// externalDNSDeploymentChanged evaluates whether or not a deployment update is necessary.
+// Returns a boolean if an update is necessary, and the deployment resource to update to.
+func externalDNSDeploymentChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if len(current.Spec.Template.Spec.Containers) > 0 && len(expected.Spec.Template.Spec.Containers) > 0 {
+		if current.Spec.Template.Spec.Containers[0].Image != expected.Spec.Template.Spec.Containers[0].Image {
+			updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
+			changed = true
+		}
+		currArgs := append([]string{}, current.Spec.Template.Spec.Containers[0].Args...)
+		expArgs := append([]string{}, expected.Spec.Template.Spec.Containers[0].Args...)
+		sort.Strings(currArgs)
+		sort.Strings(expArgs)
+		if !cmp.Equal(currArgs, expArgs) {
+			updated.Spec.Template.Spec.Containers[0].Args = expected.Spec.Template.Spec.Containers[0].Args
+			changed = true
+		}
+	}
+
+	return changed, updated
+}

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+const (
+	namespace = "externaldns"
+	name      = "test"
+	image     = "bitname/external-dns:latest"
+)
+
+func TestDesiredExternalDNSDeployment(t *testing.T) {
+	sourceNamespace := "my-namespace"
+	externalDNS := &operatorv1alpha1.ExternalDNS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: operatorv1alpha1.ExternalDNSSpec{
+			Provider: operatorv1alpha1.ExternalDNSProvider{
+				Type: operatorv1alpha1.ProviderTypeGCP,
+			},
+			Source: operatorv1alpha1.ExternalDNSSource{
+				ExternalDNSSourceUnion: operatorv1alpha1.ExternalDNSSourceUnion{
+					Type:      operatorv1alpha1.SourceTypeService,
+					Namespace: &sourceNamespace,
+					Service: &operatorv1alpha1.ExternalDNSServiceSourceOptions{
+						ServiceType: []corev1.ServiceType{
+							corev1.ServiceTypeNodePort,
+							corev1.ServiceTypeLoadBalancer,
+							corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+				HostnameAnnotationPolicy: operatorv1alpha1.HostnameAnnotationPolicyIgnore,
+			},
+			Zones: []string{
+				"my-dns-public-zone",
+				"my-dns-private-zone",
+			},
+		},
+	}
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	depl, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+
+	if err != nil {
+		t.Errorf("expected no error from calling desiredExternalDNSDeployment, but received %v", err)
+	}
+
+	if len(depl.Spec.Template.Spec.Containers) != len(externalDNS.Spec.Zones) {
+		t.Errorf("expected externalDNS deployment to have %d containers, but found %d", len(externalDNS.Spec.Zones), len(depl.Spec.Template.Spec.Containers))
+	}
+
+	expectedArgs := []string{
+		"--provider=google",
+		"--source=service",
+		"--service-type-filter=NodePort,LoadBalancer,ClusterIP",
+		"--publish-internal-services",
+		"--ignore-hostname-annotation",
+		fmt.Sprintf("--namespace=%s", sourceNamespace),
+	}
+
+	for i, container := range depl.Spec.Template.Spec.Containers {
+		expectedCustomArgs := append(expectedArgs, fmt.Sprintf("--metrics-address=127.0.0.1:%d", metricsStartPort+i))
+		expectedCustomArgs = append(expectedCustomArgs, fmt.Sprintf("--zone-id-filter=%s", externalDNS.Spec.Zones[i]))
+		argSliceString := strings.Join(container.Args, " ")
+		for _, arg := range expectedCustomArgs {
+			if !strings.Contains(argSliceString, arg) {
+				t.Errorf("expected externalDNS container %s to contain the following argument %q, but it did not. Found args: %v",
+					container.Name, arg, container.Args)
+			}
+		}
+	}
+}
+
+func TestExternalDNSDeploymentChanged(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*appsv1.Deployment)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *appsv1.Deployment) {},
+			expect:      false,
+		},
+		{
+			description: "if externalDNS image changes",
+			mutate: func(depl *appsv1.Deployment) {
+				depl.Spec.Template.Spec.Containers[0].Image = "foo.io/test:latest"
+			},
+			expect: true,
+		},
+		{
+			description: "if externalDNS container args",
+			mutate: func(depl *appsv1.Deployment) {
+				depl.Spec.Template.Spec.Containers[0].Args = []string{"Nada"}
+			},
+			expect: true,
+		},
+		{
+			description: "if externalDNS container args order changes",
+			mutate: func(depl *appsv1.Deployment) {
+				// swap the last and the first elements
+				last := len(depl.Spec.Template.Spec.Containers[0].Args) - 1
+				tmp := depl.Spec.Template.Spec.Containers[0].Args[0]
+				depl.Spec.Template.Spec.Containers[0].Args[0] = depl.Spec.Template.Spec.Containers[0].Args[last]
+				depl.Spec.Template.Spec.Containers[0].Args[last] = tmp
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		externalDNS := &operatorv1alpha1.ExternalDNS{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: operatorv1alpha1.ExternalDNSSpec{
+				Provider: operatorv1alpha1.ExternalDNSProvider{
+					Type: operatorv1alpha1.ProviderTypeAWS,
+				},
+				Source: operatorv1alpha1.ExternalDNSSource{
+					ExternalDNSSourceUnion: operatorv1alpha1.ExternalDNSSourceUnion{
+						Type: operatorv1alpha1.SourceTypeRoute,
+					},
+				},
+				Zones: []string{"my-dns-zone"},
+			},
+		}
+
+		serviceAccount := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		original, err := desiredExternalDNSDeployment(namespace, image, serviceAccount, externalDNS)
+		if err != nil {
+			t.Errorf("expected no error from calling desiredExternalDNSDeployment, but received %v", err)
+		}
+
+		mutated := original.DeepCopy()
+		tc.mutate(mutated)
+		if changed, updated := externalDNSDeploymentChanged(original, mutated); changed != tc.expect {
+			t.Errorf("%s, expect externalDNSDeploymentChanged to be %t, got %t", tc.description, tc.expect, changed)
+		} else if changed {
+			if changedAgain, _ := externalDNSDeploymentChanged(mutated, updated); changedAgain {
+				t.Errorf("%s, externalDNSDeploymentChanged does not behave as a fixed point function", tc.description)
+			}
+		}
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -17,6 +17,12 @@ limitations under the License.
 package externaldnscontroller
 
 import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 )
 
@@ -26,4 +32,18 @@ const (
 
 func ExternalDNSResourceName(externalDNS *operatorv1alpha1.ExternalDNS) string {
 	return ExternalDNSBaseName + "-" + externalDNS.Name
+}
+
+func ExternalDNSContainerName(zone string) string {
+	return ExternalDNSBaseName + "-" + hashString(zone)
+}
+
+func hashString(str string) string {
+	hasher := getHasher()
+	hasher.Write([]byte(str))
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum(nil)))
+}
+
+func getHasher() hash.Hash {
+	return fnv.New32a()
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -20,7 +20,10 @@ import (
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 )
 
-func ExternalDNSServiceAccountName(externalDNS *operatorv1alpha1.ExternalDNS) string {
-	return "externaldns-" + externalDNS.Name
+const (
+	ExternalDNSBaseName = "external-dns"
+)
 
+func ExternalDNSResourceName(externalDNS *operatorv1alpha1.ExternalDNS) string {
+	return ExternalDNSBaseName + "-" + externalDNS.Name
 }

--- a/pkg/operator/controller/names_test.go
+++ b/pkg/operator/controller/names_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldnscontroller
+
+import (
+	"testing"
+)
+
+func TestExternalDNSContainerName(t *testing.T) {
+	testCases := []struct {
+		name   string
+		zone   string
+		expect string
+	}{
+		{
+			name:   "Nominal alphanumeric",
+			zone:   "abc123def234",
+			expect: "external-dns-n7dh5d4h677h54fq",
+		},
+		{
+			name:   "Nominal AWS",
+			zone:   "Z0323552X0970SB2UHBB",
+			expect: "external-dns-n678h689h67dh69q",
+		},
+		{
+			name:   "Very long",
+			zone:   "Z0323552X0970SB2UHBBZ0323552X0970SB2UHBBZ0323552X0970SB2UHBBZ0323552X0970SB2UHBBZ0323552X0970SB2UHBBZ0323552X0970SB2UHBBZ0323552X0970SB2UHBB",
+			expect: "external-dns-n655hfbh654h557q",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExternalDNSContainerName(tc.zone)
+			if got != tc.expect {
+				t.Errorf("expect %s container name, got %s", tc.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -31,11 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	operatorconfig "github.com/openshift/external-dns-operator/pkg/operator/config"
-	"github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns"
+	externaldnsctrl "github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns"
 )
 
 const (
-	operatorName = "externaldns_operator"
+	operatorName = "external_dns_operator"
 )
 
 // Clients holds the API clients required by Operator.
@@ -57,6 +57,7 @@ type Operator struct {
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts,verbs=get;list;watch;delete;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;delete;create;update
 
 // New creates a new operator from cliCfg and opCfg.
 func New(cliCfg *rest.Config, opCfg *operatorconfig.Config) (*Operator, error) {
@@ -86,7 +87,7 @@ func New(cliCfg *rest.Config, opCfg *operatorconfig.Config) (*Operator, error) {
 	}
 
 	// Create and register the externaldns controller with the operator manager.
-	if _, err := externaldnscontroller.New(mgr, externaldnscontroller.Config{
+	if _, err := externaldnsctrl.New(mgr, externaldnsctrl.Config{
 		Namespace: opCfg.OperandNamespace,
 		Image:     opCfg.ExternalDNSImage,
 	}); err != nil {

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,6 +296,7 @@ k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,6 +46,7 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.5.6
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
Handover from https://github.com/openshift/external-dns-operator/pull/18.
Main differences from Steve's PR:
- Missing labelselector/labels added to deployment
- `ExternalDNS.Status` made optional
- Manifests updated to use `openshift-external-dns-operator` namespace

Tried on my local cluster:
```bash
$ oc logs deploy/external-dns-operator -c operator
2021-08-04T12:15:38.200Z	INFO	using operator namespace	{"namespace": "openshift-external-dns-operator"}
2021-08-04T12:15:38.200Z	INFO	using operand namespace	{"namespace": "external-dns"}
2021-08-04T12:15:38.200Z	INFO	using ExternalDNS image	{"image": "docker.io/bitnami/external-dns:latest"}
I0804 12:15:39.252345       1 request.go:668] Waited for 1.03609362s due to client-side throttling, not priority and fairness, request: GET:https://10.217.4.1:443/apis/apps.openshift.io/v1?timeout=32s
2021-08-04T12:15:40.761Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2021-08-04T12:15:43.317Z	INFO	setup	starting externalDNS operator
2021-08-04T12:15:43.320Z	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
2021-08-04T12:15:43.320Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting EventSource	{"source": "kind source: /, Kind="}
2021-08-04T12:15:43.320Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting Controller
2021-08-04T12:15:43.422Z	INFO	controller-runtime.manager.controller.externaldns_controller	Starting workers	{"worker count": 1}
2021-08-04T12:15:43.440Z	INFO	externaldns_controller	created externaldns namespace	{"namespace": "external-dns"}
2021-08-04T12:15:43.492Z	INFO	externaldns_controller	created externalDNS service account	{"namespace": "external-dns", "name": "external-dns-sample"}
2021-08-04T12:15:43.545Z	INFO	externaldns_controller	created externalDNS deployment	{"namespace": "external-dns", "name": "external-dns-sample"}

$ oc get externaldns
NAME     AGE
sample   115s

$ oc -n external-dns get deploy,sa
NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/external-dns-sample   0/1     1            0           73m

NAME                                 SECRETS   AGE
serviceaccount/builder               2         73m
serviceaccount/default               2         73m
serviceaccount/deployer              2         73m
serviceaccount/external-dns-sample   2         73m

```