### PR TITLE
Make hostnameAnnotationPolicy optional

### DIFF
--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -396,7 +396,7 @@ type ExternalDNSSource struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=Ignore
-	// +required
+	// +optional
 	HostnameAnnotationPolicy HostnameAnnotationPolicy `json:"hostnameAnnotation"`
 
 	// FQDNTemplate sets a templated string that's used to generate DNS names

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -393,7 +393,6 @@ spec:
                     - CRD
                     type: string
                 required:
-                - hostnameAnnotation
                 - type
                 type: object
               zones:


### PR DESCRIPTION
The `hostnameAnnotationPolicy` determines if any resources with the annotation is ignored or if DNS records should always be created for it. Since there is a default value `Ignore` this does not always have to be set.