### PR TITLE
Added golangci-lint with only the default linters enabled

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,90 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+    - vendor
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  modules-download-mode: vendor
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: tab
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+  fast: false
+
+linters-settings:
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/openshift/external-dns-operator
+

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ BUNDLE_IMG ?= olm-bundle:latest
 INDEX_IMG ?= olm-bundle-index:latest
 OPM_VERSION ?= v1.17.4
 
+GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
+GOLANGCI_LINT_VERSION=v1.42.1
+
 all: build
 
 ##@ General
@@ -71,7 +74,7 @@ test: manifests generate fmt vet ## Run unit tests
 		-coverprofile coverage.out \
 		./...
 
-verify:
+verify: lint
 	hack/verify-gofmt.sh
 	hack/verify-deps.sh
 	hack/verify-generated.sh
@@ -173,3 +176,12 @@ define get-bin
 	chmod +x "$(1)" ;\
 }
 endef
+
+.PHONY: lint
+## Checks the code with golangci-lint
+lint: $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run -c .golangci.yaml --deadline=30m
+
+$(GOLANGCI_LINT_BIN):
+	mkdir -p $(BIN_DIR)
+	hack/golangci-lint.sh $(GOLANGCI_LINT_BIN)

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+GOLANGCI_VERSION="1.42.1"
+
+OUTPUT_PATH=${1:-./bin/golangci-lint}
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+
+case $GOOS in
+  linux)
+    CHECKSUM="214b093c15863430c4b66dd39df677dab6e38fc873ded147e331740d50eea51f"
+    ;;
+  darwin)
+    CHECKSUM="9c0042e91218dc1dd4eb7b54e29c7331eff081b3ac3f88b0d5df89b976fcd45c"
+    ;;
+    *)
+    echo "Unsupported OS $GOOS"
+    exit 1
+    ;;
+esac
+
+if [ "$GOARCH" != "amd64" ]; then
+  echo "Unsupported architecture $GOARCH"
+  exit 1
+fi
+
+TEMPDIR=$(mktemp -d)
+curl --silent --location -o "$TEMPDIR/golangci-lint.tar.gz" "https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_VERSION/golangci-lint-$GOLANGCI_VERSION-$GOOS-$GOARCH.tar.gz"
+tar xzf "$TEMPDIR/golangci-lint.tar.gz" --directory="$TEMPDIR"
+
+echo "$CHECKSUM" "$TEMPDIR/golangci-lint.tar.gz" | sha256sum -c --quiet
+
+BIN=$TEMPDIR/golangci-lint-$GOLANGCI_VERSION-$GOOS-$GOARCH/golangci-lint
+mv "$BIN" "$OUTPUT_PATH"
+rm -rf "$TEMPDIR"

--- a/pkg/operator/controller/credentials-secret/controller.go
+++ b/pkg/operator/controller/credentials-secret/controller.go
@@ -42,7 +42,6 @@ import (
 
 const (
 	controllerName                  = "credentials_secret_controller"
-	finalizer                       = "externaldns.olm.openshift.io/finalizer-credentials-secret"
 	credentialsSecretIndexFieldName = "credentialsSecretName"
 )
 

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -1237,7 +1237,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cl := fake.NewFakeClient(tc.existingObjects...)
+			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &reconciler{
 				client: cl,
 				scheme: test.Scheme,

--- a/pkg/operator/controller/externaldns/rbac_test.go
+++ b/pkg/operator/controller/externaldns/rbac_test.go
@@ -148,7 +148,7 @@ func TestEnsureExternalDNSClusterRole(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cl := fake.NewFakeClient(tc.existingObjects...)
+			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &reconciler{
 				client: cl,
 				scheme: test.Scheme,
@@ -450,7 +450,7 @@ func TestEnsureExternalDNSClusterRoleBinding(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cl := fake.NewFakeClient(tc.existingObjects...)
+			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &reconciler{
 				client: cl,
 				scheme: test.Scheme,

--- a/pkg/operator/controller/externaldns/service_account_test.go
+++ b/pkg/operator/controller/externaldns/service_account_test.go
@@ -102,7 +102,7 @@ func TestEnsureExternalDNSServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cl := fake.NewFakeClient(tc.existingObjects...)
+			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &reconciler{
 				client: cl,
 				scheme: test.Scheme,


### PR DESCRIPTION
[golangci-lint](https://golangci-lint.run) is a wrapper for multiple golang linters to detect common code issues.

This change adds a new make target which runs the linter and makes it a prerequisite for the `verify` target. Also added a configuration file for the linter.

Requires openshift/release#22506 to be merged first.