### PR TITLE
Add txt prefix for CNAME only providers

### DIFF
--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -224,6 +224,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
+							"--txt-prefix=external-dns-",
 							"--azure-config-file=/etc/kubernetes/azure.json",
 						},
 						VolumeMounts: []corev1.VolumeMount{
@@ -274,6 +275,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
+							"--txt-prefix=external-dns-",
 						},
 					},
 				},
@@ -333,6 +335,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
+							"--txt-prefix=external-dns-",
 							"--google-project=external-dns-gcp-project",
 						},
 						Env: []corev1.EnvVar{
@@ -389,6 +392,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
+							"--txt-prefix=external-dns-",
 						},
 					},
 				},
@@ -448,6 +452,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
+							"--txt-prefix=external-dns-",
 							"--bluecat-config-file=/etc/kubernetes/bluecat.json",
 						},
 						VolumeMounts: []corev1.VolumeMount{
@@ -497,6 +502,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--service-type-filter=ExternalName",
 							"--publish-internal-services",
 							"--ignore-hostname-annotation",
+							"--txt-prefix=external-dns-",
 							"--fqdn-template={{.Name}}.test.com",
 						},
 					},


### PR DESCRIPTION
DNS providers which support only the standard CNAME alias record (different from ALIAS A record, a la AWS Route53) should be using a prefix for TXT records to not clash with A records.

ExteranlDNS notes about this: [link](https://github.com/kubernetes-sigs/external-dns#note).
Azure issue:  [link](https://github.com/kubernetes-sigs/external-dns/issues/2082).
GCP issue: [link](https://github.com/kubernetes-sigs/external-dns/issues/262).