### PR TITLE
Bug: 2019001  OLM operators shall not be a part of realease payload.

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -8,7 +8,6 @@ COPY --from=builder /external-dns-operator/bin/external-dns-operator /usr/bin/
 COPY --from=builder /external-dns-operator/bundle/manifests /manifests
 COPY --from=builder /external-dns-operator/bundle/metadata /metadata
 ENTRYPOINT ["/usr/bin/external-dns-operator"]
-LABEL io.openshift.release.operator="true"
 LABEL io.k8s.display-name="OpenShift ExternalDNS Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of ExternalDNS." \
       maintainer="<aos-network-edge-staff@redhat.com>"


### PR DESCRIPTION
OLM operator shall not be a part of Release Payload as the release payload is composed of components that are critical to the core platform and cannot be installed through OLM (e.g. control plane and kubelet).

This commit removes this operator from release payload as it was causing olm /bundle/manifests to get copied in /manifests which CVO was consuming and causing failures as they were meant for OLM.

Signed-off-by: Miheer Salunke <miheer.salunke@gmail.com>