### PR TITLE
The command make index-image-build causes removes '---' in the yaml but leaves a blank line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ olm-manifests: manifests
 	cp -f config/rbac/auth_proxy_role_binding.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
 	cp -f config/rbac/auth_proxy_service.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator-auth-proxy_v1_service.yaml
 	# opm is unable to find CRD if the standard yaml --- is at the top
-	sed -i '/^---$$/d' $(BUNDLE_MANIFEST_DIR)/*.yaml
+	sed -i -e '/^---$$/d' -e '/^$$/d' $(BUNDLE_MANIFEST_DIR)/*.yaml
 
 .PHONY: bundle-image-build
 bundle-image-build: olm-manifests

--- a/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -359,17 +358,17 @@ spec:
                     description: Namespace instructs ExternalDNS to only acknowledge
                       source resource instances in a specific namespace.
                     type: string
-                  openshift_route:
+                  openshiftRouteOptions:
                     description: OpenShiftRoute source configuration options for specifying
                       ingress controller names.
                     properties:
-                      ocpRouterName:
+                      routerName:
                         description: If source is openshift-route then you can pass
-                          the ingress controller name or names. Based on this name
-                          external-dns will select the respective router.
+                          the ingress controller name. Based on this name external-dns
+                          will select the respective router.
                         type: string
                     required:
-                    - ocpRouterName
+                    - routerName
                     type: object
                   service:
                     description: Service describes source configuration options specific


### PR DESCRIPTION
The command make index-image-build causes removes '---' in the yaml but leaves a blank line.

OLM parses this line a blank and then does not create the CRD which is present after this blank.
With this PR we remove blank lines from the yaml files.
This fix also adds the changed CRD after running command index-image-build which have the removed blank lines.

Signed-off-by: Miheer Salunke <miheer.salunke@gmail.com>