### PR TITLE
Fixes step 2 b under Installing the `ExternalDNS` Operator using a custom index image on OperatorHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ a. Select the container runtime you want. Either podman or docker.
    ```
    
   b. In the bundle/manifests/external-dns-operator_clusterserviceversion.yaml
-     add the operator image created in Step 0 as follows - 
+     add the operator image created in Step 1 as follows - 
    ```sh
     In annotations:
     Change containerImage: quay.io/openshift/origin-external-dns-operator:latest


### PR DESCRIPTION
Fixes step 2 b under Installing the `ExternalDNS` Operator using a custom index image on OperatorHub as it indicated step 0 which should be step 1.

Signed-off-by: Miheer Salunke <miheer.salunke@gmail.com>