### PR TITLE
This commit fixes the names plural field to singular name which is needed Match Type Exact.

### DIFF
--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -77,7 +77,7 @@ spec:
                       - Exact
                       - Pattern
                       type: string
-                    names:
+                    name:
                       description: "Name is a string representing a single domain
                         value. Subdomains are included. \n e.g. my-app.my-cluster-domain.com
                         would also include foo.my-app.my-cluster-domain.com"


### PR DESCRIPTION
This commit fixes the names plural field to singular name which is needed Match Type Exact.

Signed-off-by: Miheer Salunke <miheer.salunke@gmail.com>