### PR TITLE
Add OLM bundle and backport annotations

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,3 +5,8 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: "external-dns-operator"
   operators.operatorframework.io.bundle.channels.v1: "alpha"
   operators.operatorframework.io.bundle.channel.default.v1: "alpha"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"
+  # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
+  com.redhat.delivery.backport: false
+  # this is a bundle image and should be delivered via an index image
+  com.redhat.delivery.operator.bundle: true


### PR DESCRIPTION
`annotations.yaml` will be cloned by CPaaS midstream but the added annotations won't be customized by the CPaaS build.