### PR TITLE
CPaaS: CVP bundle linting checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,14 @@ olm-manifests: manifests
 	cp -f config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml $(BUNDLE_MANIFEST_DIR)/externaldns.olm.openshift.io_crd.yaml
 	cp -f config/rbac/role.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
 	cp -f config/rbac/role_binding.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
-	cp -f config/rbac/service_account.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator_v1_serviceaccount.yaml
 	cp -f config/rbac/auth_proxy_role.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrole.yaml
 	cp -f config/rbac/auth_proxy_role_binding.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator-auth-proxy_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
 	cp -f config/rbac/auth_proxy_service.yaml $(BUNDLE_MANIFEST_DIR)/external-dns-operator-auth-proxy_v1_service.yaml
 	# opm is unable to find CRD if the standard yaml --- is at the top
 	sed -i -e '/^---$$/d' -e '/^$$/d' $(BUNDLE_MANIFEST_DIR)/*.yaml
+	# as per the recommendation of 'operator-sdk bundle validate' command
+	# strip the namespaces from the bundle manifests
+	sed -i '/namespace:/d' $(BUNDLE_MANIFEST_DIR)/*.yaml
 
 .PHONY: bundle-image-build
 bundle-image-build: olm-manifests

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
       sourceNamespace: openshift-marketplace
     EOF
     ```
-    **Note**: You can install the `ExternalDNS` Operator through the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS operator`,  and install the operator.
+    **Note**: You can install the `ExternalDNS` Operator through the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS operator`,  and install it in the `external-dns-operator` namespace.
 
 ### Running end-to-end tests
 

--- a/bundle/manifests/external-dns-operator-auth-proxy_v1_service.yaml
+++ b/bundle/manifests/external-dns-operator-auth-proxy_v1_service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     name: external-dns-operator
   name: external-dns-operator-metrics-service
-  namespace: external-dns-operator
 spec:
   ports:
   - name: https

--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -13,10 +13,11 @@ metadata:
           "spec": {
             "provider": {
               "type": "AWS",
-              "aws":
+              "aws": {
                 "credentials": {
                   "name": "aws-access-key"
                 }
+              }
             },
             "source": {
               "type": "Service"
@@ -122,6 +123,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   version: 0.0.1
+  minKubeVersion: 1.22
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/manifests/external-dns-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/external-dns-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns-operator
-  namespace: external-dns-operator


### PR DESCRIPTION
CVP bundle image linting errors/warnings:
```
time="2021-11-15T20:12:14Z" level=error msg="Error: Value external-dns-operator: invalid service account found in bundle. sa name cannot match service account defined for deployment spec in CSV"
time="2021-11-15T20:12:14Z" level=error msg="Error: Value error converting YAML to JSON: yaml: line 11: did not find expected ',' or '}': error decoding example CustomResource"
time="2021-11-15T20:12:14Z" level=error msg="Error: Value external-dns-operator-metrics-service: error validating object: metadata.namespace: Forbidden: not allowed on this type. &{map[apiVersion:v1 kind:Service metadata:map[labels:map[name:external-dns-operator] name:external-dns-operator-metrics-service namespace:external-dns-operator] spec:map[ports:[map[name:https port:8443 targetPort:https]] selector:map[name:external-dns-operator]]]}"
time="2021-11-15T20:12:14Z" level=error msg="Error: Value external-dns-operator: error validating object: metadata.namespace: Forbidden: not allowed on this type. &{map[apiVersion:v1 kind:ServiceAccount metadata:map[name:external-dns-operator namespace:external-dns-operator]]}"
time="2021-11-15T20:12:14Z" level=warning msg="Warning: Value : (external-dns-operator.v0.1.1) csv.Spec.minKubeVersion is not informed. It is recommended you provide this information. Otherwise, it would mean that your operator project can be distributed and installed in any cluster version available, which is not necessarily the case for all projects."
time="2021-11-15T20:12:14Z" level=warning msg="Warning: Value external-dns-operator.v0.1.1: checking APIs against Kubernetes version : 1.22"
```

OLM service account management's issue: https://github.com/operator-framework/operator-sdk/issues/5326

After this PR is added:
```bash
$ operator-sdk bundle validate ./bundle --select-optional suite=operatorframework
INFO[0000] Found annotations file                        bundle-dir=bundle container-tool=docker
INFO[0000] Could not find optional dependencies file     bundle-dir=bundle container-tool=docker
INFO[0000] All validation tests have completed successfully 
```