### PR TITLE
CPaaS: CVP test fixes - minKubeVersion, duplicates in metadata

### DIFF
--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: ">=4.6.0 <4.10.0"
+    olm.skipRange: ">=4.6.0 <4.9.0"
     certified: "false"
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
@@ -122,8 +122,8 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc.
-  version: 0.0.1
-  minKubeVersion: 1.22
+  version: "0.0.1"
+  minKubeVersion: "1.22.0"
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: "external-dns-operator"
   operators.operatorframework.io.bundle.channels.v1: "alpha"
   operators.operatorframework.io.bundle.channel.default.v1: "alpha"
-  operators.operatorframework.io.bundle.channel.default.v1: "alpha"
   # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
   com.redhat.delivery.backport: false
   # this is a bundle image and should be delivered via an index image


### PR DESCRIPTION
CVP CI deployment failed with the following error:
```
2021-11-17T08:48:07.125461845Z E1117 08:48:07.125439       1 queueinformer_operator.go:290] sync {"update" "oo-httfr/install-qzvtb"} failed: bundle unpacking failed: failed to turn bundle into steps: json: cannot unmarshal number into Go struct field ClusterServiceVersionSpec.spec.minKubeVersion of type string
```

Bundle metadata had a duplicate key for `channel.default`, it failed the rendering of the templates in the midstream.