### PR TITLE
CPaaS: CVP deployment check - service account must be referenced explicitly

### DIFF
--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -101,6 +101,9 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: external-dns-operator
+      permissions:
+      - rules: []
+        serviceAccountName: external-dns-operator
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
XRef [OperatorSDK issue](https://github.com/operator-framework/operator-sdk/issues/5326) in case someone has the same problem.

Error I got from OLM:
```
2021-11-17T17:44:36.268071185Z I1117 17:44:36.268039       1 event.go:291] "Event occurred" object="oo-wcnfx/external-dns-operator" kind="Deployment" apiVersion="apps/v1" type="Normal" reason="ScalingReplicaSet" message="Scaled up replica set external-dns-operator-5f475c5c8b to 1"
2021-11-17T17:44:36.280741343Z I1117 17:44:36.280709       1 replica_set.go:588] Slow-start failure. Skipping creation of 1 pods, decrementing expectations for ReplicaSet oo-wcnfx/external-dns-operator-5f475c5c8b
2021-11-17T17:44:36.283388984Z I1117 17:44:36.283349       1 event.go:291] "Event occurred" object="oo-wcnfx/external-dns-operator-5f475c5c8b" kind="ReplicaSet" apiVersion="apps/v1" type="Warning" reason="FailedCreate" message="Error creating: pods \"external-dns-operator-5f475c5c8b-\" is forbidden: error looking up service account oo-wcnfx/external-dns-operator: serviceaccount \"external-dns-operator\" not found" 
```