### PR TITLE
e2e test: use unique hosted zone and custom resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ OPM_VERSION ?= v1.17.4
 GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION=v1.42.1
 
+COMMIT ?= $(shell git rev-parse HEAD)
+SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
+GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)"
+
 all: build
 
 ##@ General
@@ -80,6 +84,7 @@ test: manifests generate fmt vet ## Run tests.
 .PHONY: test-e2e
 test-e2e:
 	go test \
+	$(GOBUILD_VERSION_ARGS) \
 	-timeout 1h \
 	-count 1 \
 	-v \
@@ -93,11 +98,10 @@ verify: lint
 	hack/verify-generated.sh
 
 ##@ Build
-
 GO=GO111MODULE=on GOFLAGS=-mod=vendor CGO_ENABLED=0 go
 
 build-operator: ## Build operator binary, no additional checks or code generation
-	$(GO) build -o $(BIN) $(MAIN_PACKAGE)
+	$(GO) build $(GOBUILD_VERSION_ARGS) -o $(BIN) $(MAIN_PACKAGE)
 
 build: generate build-operator fmt vet ## Build operator binary.
 

--- a/cmd/external-dns-operator/main.go
+++ b/cmd/external-dns-operator/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openshift/external-dns-operator/pkg/operator"
 	operatorconfig "github.com/openshift/external-dns-operator/pkg/operator/config"
+	"github.com/openshift/external-dns-operator/pkg/version"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -51,6 +52,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
+	ctrl.Log.Info("build info", "commit", version.COMMIT)
 	ctrl.Log.Info("using operator namespace", "namespace", opCfg.OperatorNamespace)
 	ctrl.Log.Info("using operand namespace", "namespace", opCfg.OperandNamespace)
 	ctrl.Log.Info("using ExternalDNS image", "image", opCfg.ExternalDNSImage)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+var (
+	// COMMIT contains the hash of the VCS commit
+	COMMIT string
+	// SHORTCOMMIT contains the shorten version of the VCS commit's hash
+	SHORTCOMMIT string
+)


### PR DESCRIPTION
Follow-up of https://github.com/openshift/external-dns-operator/pull/62. Aims at addressing the remarks about the conflicting hosted zone and go built-in resolver.