### PR TITLE
e2e: fix not working gcp helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,20 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
     ```
     **Note**: You can install the `ExternalDNS` Operator through the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS operator`,  and install it in the `external-dns-operator` namespace.
 
-### Running end-to-end tests
+### Running end-to-end tests manually
 
 1. Deploy the operator as described above
 
 2. Set the necessary environment variables
-   In order for records created during the tests to be accessible, the e2e
-   suite creates a public hosted zone as a subdomain of an existing zone. You
-   must specify the existing zone's domain name and its zone id in the
-   environment variables `EXTDNS_PARENT_DOMAIN` and `EXTDNS_PARENT_ZONEID`,
-   respectively.
+
+   For AWS:
    ```sh
-   $ export EXTDNS_PARENT_ZONEID="ZABCD123456789"
-   $ export EXTDNS_PARENT_DOMAIN="example.com." # must include the trailing `.`
+   export KUBECONFIG=/path/to/mycluster/kubeconfig
+   export CLOUD_PROVIDER=AWS
+   export AWS_ACCESS_KEY_ID=my-aws-access-key
+   export AWS_SECRET_ACCESS_KEY=my-aws-access-secret
    ```
+   Check out [initProviderHelper()](./test/e2e/operator_test.go) for other providers.
 
 3. Run the test suite
    ```sh

--- a/test/e2e/gcp.go
+++ b/test/e2e/gcp.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
-	"time"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	dns "google.golang.org/api/dns/v1"
@@ -37,7 +37,7 @@ func newGCPHelper(gcpCredentials, gcpProjectId string) (providerTestHelper, erro
 func (g *gcpTestHelper) makeCredentialsSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gcp-access-key",
+			Name:      fmt.Sprintf("gcp-credentials-%s", randomString(16)),
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
@@ -51,25 +51,30 @@ func (g *gcpTestHelper) platform() string {
 }
 
 func (g *gcpTestHelper) ensureHostedZone(rootDomain string) (string, []string, error) {
+	gcpRootDomain := rootDomain + "."
+
 	resp, err := g.dnsService.ManagedZones.List(g.gcpProjectId).Do()
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to list hosted zones: %w", err)
+		return "", nil, fmt.Errorf("failed to list managed zones: %w", err)
 	}
 	zones := resp.ManagedZones
 	// if managed zone exists then return its id and nameservers
 	for _, zone := range zones {
-		if zone.DnsName == rootDomain {
+		if zone.DnsName == gcpRootDomain {
 			return strconv.FormatUint(zone.Id, 10), zone.NameServers, nil
 		}
 	}
 
 	// if zone does not exist, create managed zone and return its id and nameservers
 	zone, err := g.dnsService.ManagedZones.Create(g.gcpProjectId, &dns.ManagedZone{
-		CreationTime: time.Now().Format(time.RFC3339),
-		DnsName:      rootDomain,
+		// must be 1-63 characters long, must begin with a letter,
+		// end with a letter or digit, and only contain lowercase letters, digits or dashes
+		Name:        "a" + strings.ToLower(strings.ReplaceAll(rootDomain, ".", "-")),
+		DnsName:     gcpRootDomain,
+		Description: "ExternalDNS Operator test managed zone.",
 	}).Do()
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to create hosted zone: %w", err)
+		return "", nil, fmt.Errorf("error creating managed zone: %w", err)
 	}
 	return strconv.FormatUint(zone.Id, 10), zone.NameServers, nil
 }
@@ -80,7 +85,7 @@ func (g *gcpTestHelper) deleteHostedZone(zoneID string) error {
 		return fmt.Errorf("failed to retrieve dns records for zoneID %v: %w", zoneID, err)
 	}
 
-	var recordChanges *dns.Change
+	recordChanges := &dns.Change{}
 
 	// create change set deleting all DNS records which are not of NS and SOA types in managed zone
 	for len(resp.Rrsets) != 0 {
@@ -97,7 +102,7 @@ func (g *gcpTestHelper) deleteHostedZone(zoneID string) error {
 			token := resp.NextPageToken
 			resp, err = g.dnsService.ResourceRecordSets.List(g.gcpProjectId, zoneID).PageToken(token).Do()
 			if err != nil {
-				return fmt.Errorf("failed to retrieve dns records for zoneID %v and pageToke %v: %w", zoneID, token, err)
+				return fmt.Errorf("failed to retrieve dns records for zoneID %v and pageToken %v: %w", zoneID, token, err)
 			}
 		}
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -82,11 +82,10 @@ func getGCPProjectId(kubeClient client.Client) (string, error) {
 	return infraConfig.Status.PlatformStatus.GCP.ProjectID, nil
 }
 
-func defaultExternalDNS(t *testing.T, name string, namespace string, zoneID string, rootDomain string, credsSecret *corev1.Secret, platformType string) operatorv1alpha1.ExternalDNS {
+func defaultExternalDNS(t *testing.T, name, zoneID, rootDomain string, credsSecret *corev1.Secret, platformType string, providerOptions []string) operatorv1alpha1.ExternalDNS {
 	resource := operatorv1alpha1.ExternalDNS{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 		Spec: operatorv1alpha1.ExternalDNSSpec{
 			Zones: []string{zoneID},
@@ -127,6 +126,7 @@ func defaultExternalDNS(t *testing.T, name string, namespace string, zoneID stri
 				Credentials: operatorv1alpha1.SecretReference{
 					Name: credsSecret.Name,
 				},
+				Project: &providerOptions[0],
 			},
 		}
 	default:
@@ -138,6 +138,14 @@ func defaultExternalDNS(t *testing.T, name string, namespace string, zoneID stri
 }
 
 func defaultService(name, namespace string) *corev1.Service {
+	return testService(name, namespace, corev1.ServiceTypeLoadBalancer)
+}
+
+func clusterIPService(name, namespace string) *corev1.Service {
+	return testService(name, namespace, corev1.ServiceTypeClusterIP)
+}
+
+func testService(name, namespace string, svcType corev1.ServiceType) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -150,7 +158,7 @@ func defaultService(name, namespace string) *corev1.Service {
 			Selector: map[string]string{
 				"name": "hello-openshift",
 			},
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type: svcType,
 			Ports: []corev1.ServicePort{
 				{
 					Protocol: corev1.ProtocolTCP,


### PR DESCRIPTION
Fix for https://github.com/openshift/external-dns-operator/pull/69.

Test run:
```
$ make test-e2e
go test \
-ldflags "-X github.com/openshift/external-dns-operator/pkg/version.SHORTCOMMIT=66ed8f7 -X github.com/openshift/external-dns-operator/pkg/version.COMMIT=66ed8f73b67cd0967dbb10e7a73e311f30888809" \
-timeout 1h \
-count 1 \
-v \
-tags e2e \
-run "" \
./test/e2e
I1125 00:30:45.556434   38386 request.go:665] Waited for 1.02962918s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/operators.coreos.com/v1alpha1?timeout=32s
Ensuring hosted zone: 66ed8f7.example-test.info
=== RUN   TestOperatorAvailable
--- PASS: TestOperatorAvailable (0.02s)
=== RUN   TestExternalDNSRecordLifecycle
    operator_test.go:171: Ensuring test namespace
    operator_test.go:177: Creating credentials secret
    operator_test.go:184: Creating external dns instance
    operator_test.go:192: Creating source service
    operator_test.go:237: Getting IPs of service's load balancer
    operator_test.go:251: Looking for DNS record in nameserver: ns-cloud-d1.googledomains.com.
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
    operator_test.go:260: Waiting for dns record: test-service.66ed8f7.example-test.info
--- PASS: TestExternalDNSRecordLifecycle (105.69s)
PASS
ok  	github.com/openshift/external-dns-operator/test/e2e	115.413s
```