### PR TITLE
Skip gcp and azure e2e tests to add CI jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ COMMIT ?= $(shell git rev-parse HEAD)
 SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)"
 
+# Variable to skip some e2e provider, for corner cases
+# Keep it empty or unset
+E2E_SKIP_CLOUD_PROVIDERS="gcp,azure"
+
 all: build
 
 ##@ General


### PR DESCRIPTION
Add the possibility to skip e2e test for some cloud providers. This can be used later in case of known issues with some providers but most of the time it has to be left unused.

For now, we need it to be able to add CI jobs for GCP and Azure.
GCP e2e is already added but it's still failing so we need to disable it and add the CI job (what we should have done form the very beginning).