### PR TITLE
Avoid using global variables for configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ COMMIT ?= $(shell git rev-parse HEAD)
 SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)"
 
+E2E_TIMEOUT ?= 1h
+
 all: build
 
 ##@ General
@@ -86,7 +88,7 @@ test: manifests generate fmt vet ## Run tests.
 test-e2e:
 	go test \
 	$(GOBUILD_VERSION_ARGS) \
-	-timeout 1h \
+	-timeout $(E2E_TIMEOUT) \
 	-count 1 \
 	-v \
 	-tags e2e \

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
    export AWS_ACCESS_KEY_ID=my-aws-access-key
    export AWS_SECRET_ACCESS_KEY=my-aws-access-secret
    ```
-   Check out [initProviderHelper()](./test/e2e/operator_test.go) for other providers.
+   For the other providers: check out [e2e directory](./test/e2e/).
 
 3. Run the test suite
    ```sh

--- a/api/v1alpha1/externaldns_webhook.go
+++ b/api/v1alpha1/externaldns_webhook.go
@@ -17,19 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"errors"
 	"fmt"
-
-	configv1 "github.com/openshift/api/config/v1"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	"regexp"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes"
 
 	utilErrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,40 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-const (
-	kind    = "OpenShiftAPIServer"
-	group   = "operator.openshift.io"
-	version = "v1"
-)
-
 // webhookLog is for logging in this package.
 var webhookLog = logf.Log.WithName("validating-webhook")
 
-var IsOpenShift bool
+var isOpenShift bool
 
-var PlatformStatus *configv1.PlatformStatus
-
-func (r *ExternalDNS) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return err
-	}
-	IsOpenShift = IsOCP(kubeClient)
-
-	if IsOpenShift {
-
-		var err error
-		infraConfig := &configv1.Infrastructure{}
-		if err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
-			return fmt.Errorf("failed to get infrastructure 'config': %v", err)
-		}
-
-		PlatformStatus = infraConfig.Status.PlatformStatus
-	}
-
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		Complete()
+func (r *ExternalDNS) SetupWebhookWithManager(mgr ctrl.Manager, openshift bool) error {
+	isOpenShift = openshift
+	return ctrl.NewWebhookManagedBy(mgr).For(r).Complete()
 }
 
 //+kubebuilder:webhook:path=/validate-externaldns-olm-openshift-io-v1alpha1-externaldns,mutating=false,failurePolicy=fail,sideEffects=None,groups=externaldns.olm.openshift.io,resources=externaldnses,verbs=create;update,versions=v1alpha1,name=vexternaldns.kb.io,admissionReviewVersions={v1,v1beta1}
@@ -141,7 +107,7 @@ func (r *ExternalDNS) validateHostnameAnnotationPolicy() error {
 }
 
 func (r *ExternalDNS) validateProviderCredentials() error {
-	if IsOpenShift && (r.Spec.Provider.Type == ProviderTypeAWS || r.Spec.Provider.Type == ProviderTypeGCP || r.Spec.Provider.Type == ProviderTypeAzure) {
+	if isOpenShift && (r.Spec.Provider.Type == ProviderTypeAWS || r.Spec.Provider.Type == ProviderTypeGCP || r.Spec.Provider.Type == ProviderTypeAzure) {
 		return nil
 	}
 	provider := r.Spec.Provider
@@ -168,22 +134,4 @@ func (r *ExternalDNS) validateProviderCredentials() error {
 		}
 	}
 	return nil
-}
-
-// Returns true if platform is OCP
-func IsOCP(kubeClient discovery.DiscoveryInterface) bool {
-	// Since, CRD for OpenShift API Server was introduced in OCP v4.x we can verify if the current cluster is on OCP v4.x by
-	// ensuring that resource exists against Group(operator.openshift.io), Version(v1) and Kind(OpenShiftAPIServer)
-	// In case it doesn't exist we assume that external dns is running on non OCP 4.x environment
-	resources, err := kubeClient.ServerResourcesForGroupVersion(group + "/" + version)
-	if err != nil {
-		return false
-	}
-
-	for _, apiResource := range resources.APIResources {
-		if apiResource.Kind == kind {
-			return true
-		}
-	}
-	return false
 }

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&ExternalDNS{}).SetupWebhookWithManager(mgr)
+	err = (&ExternalDNS{}).SetupWebhookWithManager(mgr, false)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -34,13 +34,13 @@ func makeExternalDNS(name string, domains []ExternalDNSDomain) *ExternalDNS {
 var _ = Describe("ExternalDNS admission webhook when platform is OCP", func() {
 	BeforeEach(func() {
 		// Add any setup steps that needs to be executed before each test
-		IsOpenShift = true
+		isOpenShift = true
 
 	})
 
 	AfterEach(func() {
 		// Add any teardown steps that needs to be executed after each test
-		IsOpenShift = false
+		isOpenShift = false
 
 	})
 

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -39,7 +39,6 @@ const (
 	DefaultOperandNamespace        = "external-dns"
 	DefaultEnableWebhook           = true
 	DefaultEnablePlatformDetection = true
-	DefaultIsOpenShift             = false
 
 	openshiftKind              = "OpenShiftAPIServer"
 	openshiftResourceGroup     = "operator.openshift.io"
@@ -73,28 +72,14 @@ type Config struct {
 	// EnableWebhook is the flag indicating if the webhook server should be started.
 	EnableWebhook bool
 
-	// EnablePlatformDetection is the flag indicating if the operator needs to detect on which platform it runs
+	// EnablePlatformDetection is the flag indicating if the operator needs to detect on which platform it runs.
 	EnablePlatformDetection bool
 
-	// IsOpenShift is the flag indicating that the operator runs in OpenShift cluster
+	// IsOpenShift is the flag indicating that the operator runs in OpenShift cluster.
 	IsOpenShift bool
 
-	// PlatformStatus is the details about the undelying platform
+	// PlatformStatus is the details about the underlying platform.
 	PlatformStatus *configv1.PlatformStatus
-}
-
-// New returns an operator config using default values.
-func New() *Config {
-	return &Config{
-		ExternalDNSImage:        DefaultExternalDNSImage,
-		MetricsBindAddress:      DefaultMetricsAddr,
-		OperatorNamespace:       DefaultOperatorNamespace,
-		OperandNamespace:        DefaultOperandNamespace,
-		CertDir:                 DefaultCertDir,
-		EnableWebhook:           DefaultEnableWebhook,
-		EnablePlatformDetection: DefaultEnablePlatformDetection,
-		IsOpenShift:             DefaultIsOpenShift,
-	}
 }
 
 // DetectPlatform detects the underlying platform and fills corresponding config fields

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -17,17 +17,34 @@ limitations under the License.
 package config
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	configv1 "github.com/openshift/api/config/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	// TODO (alebedev): CPaaS onboarding is ongoing to replace this with Red Hat built image
-	DefaultExternalDNSImage  = "k8s.gcr.io/external-dns/external-dns:v0.8.0"
-	DefaultMetricsAddr       = "127.0.0.1:8080"
-	DefaultOperatorNamespace = "external-dns-operator"
-	DefaultOperandNamespace  = "external-dns"
-	DefaultEnableWebhook     = true
+	DefaultExternalDNSImage        = "k8s.gcr.io/external-dns/external-dns:v0.8.0"
+	DefaultMetricsAddr             = "127.0.0.1:8080"
+	DefaultOperatorNamespace       = "external-dns-operator"
+	DefaultOperandNamespace        = "external-dns"
+	DefaultEnableWebhook           = true
+	DefaultEnablePlatformDetection = true
+	DefaultIsOpenShift             = false
+
+	openshiftKind              = "OpenShiftAPIServer"
+	openshiftResourceGroup     = "operator.openshift.io"
+	openshiftResourceVersion   = "v1"
+	openshiftClusterConfigName = "cluster"
 )
 
 var (
@@ -55,16 +72,70 @@ type Config struct {
 
 	// EnableWebhook is the flag indicating if the webhook server should be started.
 	EnableWebhook bool
+
+	// EnablePlatformDetection is the flag indicating if the operator needs to detect on which platform it runs
+	EnablePlatformDetection bool
+
+	// IsOpenShift is the flag indicating that the operator runs in OpenShift cluster
+	IsOpenShift bool
+
+	// PlatformStatus is the details about the undelying platform
+	PlatformStatus *configv1.PlatformStatus
 }
 
 // New returns an operator config using default values.
 func New() *Config {
 	return &Config{
-		ExternalDNSImage:   DefaultExternalDNSImage,
-		MetricsBindAddress: DefaultMetricsAddr,
-		OperatorNamespace:  DefaultOperatorNamespace,
-		OperandNamespace:   DefaultOperandNamespace,
-		CertDir:            DefaultCertDir,
-		EnableWebhook:      DefaultEnableWebhook,
+		ExternalDNSImage:        DefaultExternalDNSImage,
+		MetricsBindAddress:      DefaultMetricsAddr,
+		OperatorNamespace:       DefaultOperatorNamespace,
+		OperandNamespace:        DefaultOperandNamespace,
+		CertDir:                 DefaultCertDir,
+		EnableWebhook:           DefaultEnableWebhook,
+		EnablePlatformDetection: DefaultEnablePlatformDetection,
+		IsOpenShift:             DefaultIsOpenShift,
 	}
+}
+
+// DetectPlatform detects the underlying platform and fills corresponding config fields
+func (c *Config) DetectPlatform(kubeConfig *rest.Config) error {
+	if c.EnablePlatformDetection {
+		kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+		if err != nil {
+			return err
+		}
+
+		c.IsOpenShift = isOCP(kubeClient)
+	}
+	return nil
+}
+
+// FillPlatformDetails fills the config with the platform details
+func (c *Config) FillPlatformDetails(ctx context.Context, ctrlClient ctrlclient.Client) error {
+	if c.IsOpenShift {
+		infraConfig := &configv1.Infrastructure{}
+		if err := ctrlClient.Get(ctx, types.NamespacedName{Name: openshiftClusterConfigName}, infraConfig); err != nil {
+			return fmt.Errorf("failed to get infrastructure config: %w", err)
+		}
+		c.PlatformStatus = infraConfig.Status.PlatformStatus
+	}
+	return nil
+}
+
+// isOCP returns true if the platform is OCP
+func isOCP(kubeClient discovery.DiscoveryInterface) bool {
+	// Since, CRD for OpenShift API Server was introduced in OCP v4.x we can verify if the current cluster is on OCP v4.x by
+	// ensuring that resource exists against Group(operator.openshift.io), Version(v1) and Kind(OpenShiftAPIServer)
+	// In case it doesn't exist we assume that external dns is running on non OCP 4.x environment
+	resources, err := kubeClient.ServerResourcesForGroupVersion(openshiftResourceGroup + "/" + openshiftResourceVersion)
+	if err != nil {
+		return false
+	}
+
+	for _, apiResource := range resources.APIResources {
+		if apiResource.Kind == openshiftKind {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/operator/controller/credentials-secret/controller.go
+++ b/pkg/operator/controller/credentials-secret/controller.go
@@ -225,6 +225,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get externalDNS %q: %w", request.NamespacedName, err)
 	}
 
+	// get the source secret name and whether it came from ExternalDNS CR or not
 	srcSecretNameOnly, fromCR := getExternalDNSCredentialsSecretNameWithTrace(extDNS, r.config.IsOpenShift)
 	srcSecretName := types.NamespacedName{
 		Namespace: r.config.SourceNamespace,

--- a/pkg/operator/controller/externaldns/controller_test.go
+++ b/pkg/operator/controller/externaldns/controller_test.go
@@ -68,7 +68,6 @@ func TestReconcile(t *testing.T) {
 		expectedResult  reconcile.Result
 		expectedEvents  []testEvent
 		errExpected     bool
-		ocpPlatform     bool
 	}{
 		{
 			name:            "Bootstrap",
@@ -126,9 +125,8 @@ func TestReconcile(t *testing.T) {
 		{
 			name:            "Bootstrap when OCP",
 			existingObjects: []runtime.Object{testExtDNSInstance(), testSecret()},
-			inputConfig:     testConfig(),
+			inputConfig:     testConfigOpenShift(),
 			inputRequest:    testRequest(),
-			ocpPlatform:     true,
 			expectedResult:  reconcile.Result{},
 			expectedEvents: []testEvent{
 				{
@@ -203,8 +201,6 @@ func TestReconcile(t *testing.T) {
 				config: tc.inputConfig,
 				log:    zap.New(zap.UseDevMode(true)),
 			}
-
-			operatorv1alpha1.IsOpenShift = tc.ocpPlatform
 
 			// get watch interfaces from all the type managed by the operator
 			watches := []watch.Interface{}
@@ -325,6 +321,14 @@ func testConfig() Config {
 	return Config{
 		Namespace: test.OperandNamespace,
 		Image:     test.OperandImage,
+	}
+}
+
+func testConfigOpenShift() Config {
+	return Config{
+		Namespace:   test.OperandNamespace,
+		Image:       test.OperandImage,
+		IsOpenShift: true,
 	}
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,26 @@
+/*
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+// ManagedCredentialsProvider returns true if the credentials of the ExternalDNS provider can be managed by the platform
+func ManagedCredentialsProvider(e *operatorv1alpha1.ExternalDNS) bool {
+	switch e.Spec.Provider.Type {
+	case operatorv1alpha1.ProviderTypeAWS, operatorv1alpha1.ProviderTypeGCP, operatorv1alpha1.ProviderTypeAzure:
+		return true
+	}
+	return false
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,8 @@
 /*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package version
 
 var (

--- a/test/e2e/aws.go
+++ b/test/e2e/aws.go
@@ -27,6 +27,8 @@ type awsTestHelper struct {
 	secretKey string
 }
 
+var _ providerTestHelper = &awsTestHelper{}
+
 func newAWSHelper(isOpenShiftCI bool, kubeClient client.Client) (providerTestHelper, error) {
 	provider := &awsTestHelper{}
 	if err := provider.prepareConfigurations(isOpenShiftCI, kubeClient); err != nil {

--- a/test/e2e/azure.go
+++ b/test/e2e/azure.go
@@ -38,6 +38,8 @@ type azureTestHelper struct {
 	zoneClient dns.ZonesClient
 }
 
+var _ providerTestHelper = &azureTestHelper{}
+
 // Build the necessary object for the provider test
 // for Azure Need the credentials ref clusterConfig
 func newAzureHelper(kubeClient client.Client) (providerTestHelper, error) {

--- a/test/e2e/gcp.go
+++ b/test/e2e/gcp.go
@@ -28,22 +28,24 @@ type gcpTestHelper struct {
 	providerOptions []string
 }
 
+var _ providerTestHelper = &gcpTestHelper{}
+
 func newGCPHelper(isOpenShiftCI bool, kubeClient client.Client) (providerTestHelper, error) {
-	provier := &gcpTestHelper{}
-	err := provier.prepareConfigurations(isOpenShiftCI, kubeClient)
+	provider := &gcpTestHelper{}
+	err := provider.prepareConfigurations(isOpenShiftCI, kubeClient)
 	if err != nil {
 		return nil, err
 	}
 
-	provier.dnsService, err = dns.NewService(context.Background(), option.WithCredentialsJSON([]byte(provier.gcpCredentials)))
+	provider.dnsService, err = dns.NewService(context.Background(), option.WithCredentialsJSON([]byte(provider.gcpCredentials)))
 	if err != nil {
 		return nil, fmt.Errorf("could not authenticate with the given credentials: %w", err)
 	}
 
-	return provier, nil
+	return provider, nil
 }
 
-func (a *gcpTestHelper) buildExternalDNS(name, zoneID, zoneDomain string, credsSecret *corev1.Secret) operatorv1alpha1.ExternalDNS {
+func (g *gcpTestHelper) buildExternalDNS(name, zoneID, zoneDomain string, credsSecret *corev1.Secret) operatorv1alpha1.ExternalDNS {
 	resource := defaultExternalDNS(name, zoneID, zoneDomain)
 	resource.Spec.Provider = operatorv1alpha1.ExternalDNSProvider{
 		Type: operatorv1alpha1.ProviderTypeGCP,
@@ -51,11 +53,12 @@ func (a *gcpTestHelper) buildExternalDNS(name, zoneID, zoneDomain string, credsS
 			Credentials: operatorv1alpha1.SecretReference{
 				Name: credsSecret.Name,
 			},
-			Project: &a.gcpProjectId,
+			Project: &g.gcpProjectId,
 		},
 	}
 	return resource
 }
+
 func (g *gcpTestHelper) makeCredentialsSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Current situation**
The setup of the webhook checks for OpenShift API to set a global `api/v1alpha1` package variable which indicates whether it's openshift or not. In the same place the infrastructure config is retrieved and and another global variable for `PlatformStatus` is set in the same package. The rest of the code uses this to switchcase between pure Kubernetes and OpenShift installations.

_Problem 1_: platform detection and status have no logical adherence to the API wehbook. This is something which has to be done once but the webhook is not optimal place for this. 
_Problem 2_: testing with global variables is more difficult as the functions depend on external variants which are not easy to set and even more difficult to be reset to the previous values.

**Proposal**
Move the platform specific things into the operator's config: `pkg/operator/config#Config`. The platform gets detected in main (only Kube client is needed), the platforms status gets retrieved at the operator initialization (we already know the platform and can use the specific client). Then these data is propagated to the places where it's needed.

_Result_: the things which have to be done once are not bound to the webhook setup, fewer dependencies on the global variables. Slightly (a couple of %) better code coverage.
 
 
 **Bonus**
 Discovered by e2e testing of the proposal: credentials secret specified in `ExternalDNS` CR is not used when the platform is OpenShift. Fix this to give the priority to explicitly specified secret.
 