### PR TITLE
Enable golangci-lint for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ INDEX_IMG ?= olm-bundle-index:latest
 OPM_VERSION ?= v1.17.4
 
 GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION=v1.42.1
+GOLANGCI_LINT_VERSION=v1.43.0
 
 COMMIT ?= $(shell git rev-parse HEAD)
 SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
@@ -209,6 +209,7 @@ endef
 ## Checks the code with golangci-lint
 lint: $(GOLANGCI_LINT_BIN)
 	$(GOLANGCI_LINT_BIN) run -c .golangci.yaml --deadline=30m
+	$(GOLANGCI_LINT_BIN) run --build-tags e2e -c .golangci.yaml --deadline=30m
 
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(BIN_DIR)

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-GOLANGCI_VERSION="1.42.1"
+GOLANGCI_VERSION="1.43.0"
 
 OUTPUT_PATH=${1:-./bin/golangci-lint}
 
@@ -10,10 +10,10 @@ GOARCH=$(go env GOARCH)
 
 case $GOOS in
   linux)
-    CHECKSUM="214b093c15863430c4b66dd39df677dab6e38fc873ded147e331740d50eea51f"
+    CHECKSUM="f3515cebec926257da703ba0a2b169e4a322c11dc31a8b4656b50a43e48877f4"
     ;;
   darwin)
-    CHECKSUM="9c0042e91218dc1dd4eb7b54e29c7331eff081b3ac3f88b0d5df89b976fcd45c"
+    CHECKSUM="5971ed73d25767b2b955a694e59c7381d56df46e3681a93e067c601d0d6cffad"
     ;;
     *)
     echo "Unsupported OS $GOOS"

--- a/test/e2e/aws.go
+++ b/test/e2e/aws.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e

--- a/test/e2e/azure.go
+++ b/test/e2e/azure.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -8,17 +9,16 @@ import (
 	"fmt"
 	"strings"
 
-	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 )
 
 // clusterConfig represents common config items for Azure DNS and Azure Private DNS

--- a/test/e2e/gcp.go
+++ b/test/e2e/gcp.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -8,24 +9,22 @@ import (
 	"strconv"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
-
-	"google.golang.org/api/option"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	configv1 "github.com/openshift/api/config/v1"
-	dns "google.golang.org/api/dns/v1"
 )
 
 type gcpTestHelper struct {
-	dnsService      *dns.Service
-	gcpCredentials  string
-	gcpProjectId    string
-	providerOptions []string
+	dnsService     *dns.Service
+	gcpCredentials string
+	gcpProjectId   string
 }
 
 var _ providerTestHelper = &gcpTestHelper{}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -5,7 +6,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/miekg/dns"
 	"math/rand"
 	"os"
 	"reflect"
@@ -13,19 +13,18 @@ import (
 	"testing"
 	"time"
 
-	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
-
+	"github.com/miekg/dns"
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	routev1 "github.com/openshift/api/route/v1"
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 )
 
 type providerTestHelper interface {
@@ -57,10 +56,6 @@ func getPlatformType(kubeClient client.Client) (string, error) {
 
 func defaultService(name, namespace string) *corev1.Service {
 	return testService(name, namespace, corev1.ServiceTypeLoadBalancer)
-}
-
-func clusterIPService(name, namespace string) *corev1.Service {
-	return testService(name, namespace, corev1.ServiceTypeClusterIP)
 }
 
 func testRoute(name, namespace, host, svcName string) *routev1.Route {


### PR DESCRIPTION
The e2e test files use build tags which prevent the linter from correctly detecting issues. This change runs the linter twice, one without any build tags and once with. Also fixed all issues detected.