### PR TITLE
Add the bundle generation check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ INDEX_IMG ?= olm-bundle-index:latest
 OPM_VERSION ?= v1.17.4
 
 GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION=v1.43.0
+
+OPERATOR_SDK_BIN=$(BIN_DIR)/operator-sdk
 
 COMMIT ?= $(shell git rev-parse HEAD)
 SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
@@ -99,6 +100,7 @@ verify: lint
 	hack/verify-gofmt.sh
 	hack/verify-deps.sh
 	hack/verify-generated.sh
+	hack/verify-olm.sh
 
 ##@ Build
 GO=GO111MODULE=on GOFLAGS=-mod=vendor CGO_ENABLED=0 go
@@ -132,6 +134,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+.SILENT: olm-manifests
 .PHONY: olm-manifests
 # TODO: try to replace this rule with 'operator-sdk generate bundle'
 # A little helper command to generate the manifests of OLM bundle from the files in config/.
@@ -154,8 +157,8 @@ olm-manifests: manifests
 	for f in $$(\grep -l 'kind: *\(Service\|ConfigMap\|Secret\|Role\) *$$' $(BUNDLE_MANIFEST_DIR)/*.yaml); do sed -i '/namespace:/d' $${f};done
 
 .PHONY: validate-bundle
-validate-bundle:
-	operator-sdk bundle validate $(BUNDLE_DIR) --select-optional suite=operatorframework
+validate-bundle: $(OPERATOR_SDK_BIN)
+	$(OPERATOR_SDK_BIN) bundle validate $(BUNDLE_DIR) --select-optional suite=operatorframework
 
 .PHONY: bundle-image-build
 bundle-image-build: olm-manifests
@@ -214,3 +217,7 @@ lint: $(GOLANGCI_LINT_BIN)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(BIN_DIR)
 	hack/golangci-lint.sh $(GOLANGCI_LINT_BIN)
+
+$(OPERATOR_SDK_BIN):
+	mkdir -p $(BIN_DIR)
+	hack/operator-sdk.sh $(OPERATOR_SDK_BIN)

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -408,7 +408,11 @@ spec:
               zones:
                 description: "Zones describes which DNS Zone IDs ExternalDNS should
                   publish records to. \n Updating this field after creation will cause
-                  all DNS records in the previous zone(s) to be left behind."
+                  all DNS records in the previous zone(s) to be left behind. \n An
+                  empty list of zones means that the ExternalDNS will publish to all
+                  zones (i.e public and private), unless the operator runs on a platform
+                  on which the operator can lookup a default set of zones e.g on OpenShift
+                  with its cluster DNS config"
                 items:
                   type: string
                 maxItems: 10

--- a/hack/operator-sdk.sh
+++ b/hack/operator-sdk.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+
+VERSION="1.15.0"
+
+OUTPUT_PATH=${1:-./bin/operator-sdk}
+VERIFY=${2:-yes}
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+BIN="operator-sdk"
+BIN_ARCH="${BIN}_${GOOS}_${GOARCH}"
+OPERATOR_SDK_DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/v${VERSION}"
+
+case ${GOOS} in
+  linux)
+    CHECKSUM="d2065f1f7a0d03643ad71e396776dac0ee809ef33195e0f542773b377bab1b2a"
+    ;;
+  darwin)
+    CHECKSUM="5fc30d04a31736449adb5c9b0b44e78ebeaa5cf968cc7afcbdf533135b72e31a"
+    ;;
+    *)
+    echo "Unsupported OS $GOOS"
+    exit 1
+    ;;
+esac
+
+if [ "$GOARCH" != "amd64" ]; then
+  echo "Unsupported architecture $GOARCH"
+  exit 1
+fi
+
+command -v curl &> /dev/null || { echo "can't find curl command" && exit 1; }
+command -v sha256sum &> /dev/null || { echo "can't find sha256sum command" && exit 1; }
+
+TEMPDIR=$(mktemp -d)
+BIN_PATH="${TEMPDIR}/${BIN_ARCH}"
+
+echo "> downloading binary"
+curl --silent --location -o "${BIN_PATH}" "${OPERATOR_SDK_DL_URL}/operator-sdk_${GOOS}_${GOARCH}"
+
+if [ "${VERIFY}" == "yes" ]; then
+    echo "> verifying binary"
+    echo "${CHECKSUM} ${BIN_PATH}" | sha256sum -c --quiet
+fi
+
+echo "> installing binary"
+mv "${BIN_PATH}" "${OUTPUT_PATH}"
+chmod +x "${OUTPUT_PATH}"
+rm -rf "${TEMPDIR}"

--- a/hack/verify-olm.sh
+++ b/hack/verify-olm.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
+
 set -euo pipefail
 
 function print_failure {
-  echo "There are unexpected changes to the tree when running 'make generate' and 'make manifests'. Please"
+  echo "There are unexpected changes to the tree when running 'make olm-manifests'. Please"
   echo "run these commands locally and double-check the Git repository for unexpected changes which may"
   echo "need to be committed."
   exit 1
 }
 
 if [ "${OPENSHIFT_CI:-false}" = true ]; then
-  make generate
-  make manifests
-
+  echo "> generating the OLM bundle"
+  make olm-manifests
   test -z "$(git status --porcelain | \grep -v '^??')" || print_failure
-  echo "verified generated manifests and deep copy"
+
+  echo "> verifying the OLM bundle"
+  make validate-bundle
+
+  echo "> verified generated bundle and deep copy"
 fi


### PR DESCRIPTION
Add a new script to `make verify` target which:
- checks that the OLM bundle was updated with the latest files from `config/`
- runs `operator-sdk` bundle validation