### PR TITLE
CRD fixes from #105 API review

### DIFF
--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -368,7 +368,7 @@ type ExternalDNSInfobloxProviderOptions struct {
 }
 
 // SecretReference contains the information to let you locate the desired secret.
-// Secret is expected to be in the operator namespace.
+// Secret is required to be in the operator namespace.
 type SecretReference struct {
 	// Name is the name of the secret.
 	//
@@ -418,7 +418,10 @@ type ExternalDNSSource struct {
 	// from sources that don't define a hostname themselves.
 	// Multiple global FQDN templates are possible.
 	//
-	// Should not be empty when HostnameAnnotationPolicy is set to Ignore.
+	// This field must be specified with a nonempty value if the source type
+	// is Service or CRD and HostnameAnnotationPolicy is set to Ignore.  The
+	// field value may be omitted or empty if HostnameAnnotationPolicy is
+	// set to Allow or if the source type is OpenShiftRoute.
 	//
 	// Provided templates should follow the syntax defined for text/template Go package,
 	// see https://pkg.go.dev/text/template.
@@ -442,8 +445,11 @@ type ExternalDNSSourceUnion struct {
 	// +required
 	Type ExternalDNSSourceType `json:"type"`
 
-	// LabelFilter specifies a label selector used to filter which source instance resources ExternalDNS publishes
-	// records for. The filter uses label selector semantics against source resource labels.
+	// LabelFilter specifies a label selector for filtering the objects for
+	// which ExternalDNS publishes records. The filter uses label selector
+	// semantics against object labels.  Specifying a null or empty label
+	// selector causes ExternalDNS to publish records for all objects of the
+	// source type resource.
 	//
 	// +kubebuilder:validation:Optional
 	// +optional
@@ -510,7 +516,11 @@ type ExternalDNSServiceSourceOptions struct {
 }
 
 type ExternalDNSOpenShiftRouteOptions struct {
-	// If source is openshift-route then you can pass the ingress controller name. Based on this name external-dns will select the respective router.
+	// RouterName is the name of a router (AKA ingress controller) as
+	// reported in Route.status.ingress[].routerName.  External-dns will use
+	// the canonical hostname of the router identified by this name when
+	// publishing records for a given route.
+	//
 	// +kubebuilder:validation:Required
 	// +required
 	RouterName string `json:"routerName"`

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -59,6 +59,7 @@ type ExternalDNSSpec struct {
 	// Excluding DNS records that were previous included via a resource update
 	// will *not* result in the original DNS records being deleted.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Domains []ExternalDNSDomain `json:"domains,omitempty"`
 
@@ -96,6 +97,7 @@ type ExternalDNSSpec struct {
 	// DNS config
 	//
 	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:Optional
 	// +optional
 	Zones []string `json:"zones,omitempty"`
 }
@@ -154,6 +156,7 @@ type ExternalDNSDomainUnion struct {
 	// would also include
 	// foo.my-app.my-cluster-domain.com
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Name *string `json:"name,omitempty"`
 
@@ -163,6 +166,7 @@ type ExternalDNSDomainUnion struct {
 	// used by the go regexp package (RE2).
 	// See https://golang.org/pkg/regexp/ for more information.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Pattern *string `json:"pattern,omitempty"`
 }
@@ -205,30 +209,35 @@ type ExternalDNSProvider struct {
 	// AWS describes provider configuration options
 	// specific to AWS (Route 53).
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	AWS *ExternalDNSAWSProviderOptions `json:"aws,omitempty"`
 
 	// GCP describes provider configuration options
 	// specific to GCP (Google DNS).
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	GCP *ExternalDNSGCPProviderOptions `json:"gcp,omitempty"`
 
 	// Azure describes provider configuration options
 	// specific to Azure DNS.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Azure *ExternalDNSAzureProviderOptions `json:"azure,omitempty"`
 
 	// BlueCat describes provider configuration options
 	// specific to BlueCat DNS.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	BlueCat *ExternalDNSBlueCatProviderOptions `json:"blueCat,omitempty"`
 
 	// Infoblox describes provider configuration options
 	// specific to Infoblox DNS.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Infoblox *ExternalDNSInfobloxProviderOptions `json:"infoblox,omitempty"`
 }
@@ -258,6 +267,7 @@ type ExternalDNSGCPProviderOptions struct {
 	// when running on GCP as externalDNS auto-detects
 	// the GCP project to use when running on GCP.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Project *string `json:"project,omitempty"`
 
@@ -435,12 +445,14 @@ type ExternalDNSSourceUnion struct {
 	// LabelFilter specifies a label selector used to filter which source instance resources ExternalDNS publishes
 	// records for. The filter uses label selector semantics against source resource labels.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	LabelFilter *metav1.LabelSelector `json:"labelFilter,omitempty"`
 
 	// Service describes source configuration options specific
 	// to the service source resource.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	Service *ExternalDNSServiceSourceOptions `json:"service,omitempty"`
 
@@ -540,6 +552,7 @@ type ExternalDNSCRDSourceOptions struct {
 	// Only one label filter can be specified on
 	// an ExternalDNS instance.
 	//
+	// +kubebuilder:validation:Optional
 	// +optional
 	LabelFilter *metav1.LabelSelector `json:"labelFilter,omitempty"`
 }

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -399,8 +399,8 @@ type ExternalDNSSource struct {
 	// may grant privileged DNS permissions to under-privileged cluster
 	// users.
 	//
-	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=Ignore
+	// +kubebuilder:validation:Optional
 	// +optional
 	HostnameAnnotationPolicy HostnameAnnotationPolicy `json:"hostnameAnnotation"`
 

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -337,21 +337,21 @@ type ExternalDNSInfobloxProviderOptions struct {
 
 	// GridHost is the IP of the Infoblox Grid host.
 	//
-	// kubebuilder:validation:Required
+	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="127.0.0.1"
 	// +required
 	GridHost string `json:"gridHost"`
 
 	// WAPIPort is the port for the Infoblox WAPI.
 	//
-	// kubebuilder:validation:Required
+	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=443
 	// +required
 	WAPIPort int `json:"wapiPort"`
 
 	// WAPIVersion is the version of the Infoblox WAPI.
 	//
-	// kubebuilder:validation:Required
+	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="2.3.1"
 	// +required
 	WAPIVersion string `json:"wapiVersion"`

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -462,7 +462,9 @@ type ExternalDNSSourceUnion struct {
 	// +optional
 	Service *ExternalDNSServiceSourceOptions `json:"service,omitempty"`
 
-	// OpenShiftRoute source configuration options for specifying ingress controller names.
+	// OpenShiftRoute describes source configuration options specific to the
+	// routes.route.openshift.io resource.
+	//
 	// +kubebuilder:validation:Optional
 	// +optional
 	OpenShiftRoute *ExternalDNSOpenShiftRouteOptions `json:"openshiftRouteOptions,omitempty"`

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -251,13 +251,16 @@ spec:
                     description: "FQDNTemplate sets a templated string that's used
                       to generate DNS names from sources that don't define a hostname
                       themselves. Multiple global FQDN templates are possible. \n
-                      Should not be empty when HostnameAnnotationPolicy is set to
-                      Ignore. \n Provided templates should follow the syntax defined
-                      for text/template Go package, see https://pkg.go.dev/text/template.
-                      Annotations inside the template correspond to the definition
-                      of the source resource object (e.g. Kubernetes service, OpenShift
-                      route). Example: \"{{.Name}}.example.com\" would be expanded
-                      to \"myservice.example.com\" for service source"
+                      This field must be specified with a nonempty value if the source
+                      type is Service or CRD and HostnameAnnotationPolicy is set to
+                      Ignore.  The field value may be omitted or empty if HostnameAnnotationPolicy
+                      is set to Allow or if the source type is OpenShiftRoute. \n
+                      Provided templates should follow the syntax defined for text/template
+                      Go package, see https://pkg.go.dev/text/template. Annotations
+                      inside the template correspond to the definition of the source
+                      resource object (e.g. Kubernetes service, OpenShift route).
+                      Example: \"{{.Name}}.example.com\" would be expanded to \"myservice.example.com\"
+                      for service source"
                     items:
                       type: string
                     type: array
@@ -277,10 +280,11 @@ spec:
                     - Allow
                     type: string
                   labelFilter:
-                    description: LabelFilter specifies a label selector used to filter
-                      which source instance resources ExternalDNS publishes records
-                      for. The filter uses label selector semantics against source
-                      resource labels.
+                    description: LabelFilter specifies a label selector for filtering
+                      the objects for which ExternalDNS publishes records. The filter
+                      uses label selector semantics against object labels.  Specifying
+                      a null or empty label selector causes ExternalDNS to publish
+                      records for all objects of the source type resource.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -328,9 +332,10 @@ spec:
                       ingress controller names.
                     properties:
                       routerName:
-                        description: If source is openshift-route then you can pass
-                          the ingress controller name. Based on this name external-dns
-                          will select the respective router.
+                        description: RouterName is the name of a router (AKA ingress
+                          controller) as reported in Route.status.ingress[].routerName.  External-dns
+                          will use the canonical hostname of the router identified
+                          by this name when publishing records for a given route.
                         type: string
                     required:
                     - routerName

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -328,8 +328,8 @@ spec:
                         type: object
                     type: object
                   openshiftRouteOptions:
-                    description: OpenShiftRoute source configuration options for specifying
-                      ingress controller names.
+                    description: OpenShiftRoute describes source configuration options
+                      specific to the routes.route.openshift.io resource.
                     properties:
                       routerName:
                         description: RouterName is the name of a router (AKA ingress

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -210,18 +210,15 @@ spec:
                         type: object
                       gridHost:
                         default: 127.0.0.1
-                        description: "GridHost is the IP of the Infoblox Grid host.
-                          \n kubebuilder:validation:Required"
+                        description: GridHost is the IP of the Infoblox Grid host.
                         type: string
                       wapiPort:
                         default: 443
-                        description: "WAPIPort is the port for the Infoblox WAPI.
-                          \n kubebuilder:validation:Required"
+                        description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer
                       wapiVersion:
                         default: 2.3.1
-                        description: "WAPIVersion is the version of the Infoblox WAPI.
-                          \n kubebuilder:validation:Required"
+                        description: WAPIVersion is the version of the Infoblox WAPI.
                         type: string
                     required:
                     - credentials

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -212,18 +212,15 @@ spec:
                         type: object
                       gridHost:
                         default: 127.0.0.1
-                        description: "GridHost is the IP of the Infoblox Grid host.
-                          \n kubebuilder:validation:Required"
+                        description: GridHost is the IP of the Infoblox Grid host.
                         type: string
                       wapiPort:
                         default: 443
-                        description: "WAPIPort is the port for the Infoblox WAPI.
-                          \n kubebuilder:validation:Required"
+                        description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer
                       wapiVersion:
                         default: 2.3.1
-                        description: "WAPIVersion is the version of the Infoblox WAPI.
-                          \n kubebuilder:validation:Required"
+                        description: WAPIVersion is the version of the Infoblox WAPI.
                         type: string
                     required:
                     - credentials

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -253,13 +253,16 @@ spec:
                     description: "FQDNTemplate sets a templated string that's used
                       to generate DNS names from sources that don't define a hostname
                       themselves. Multiple global FQDN templates are possible. \n
-                      Should not be empty when HostnameAnnotationPolicy is set to
-                      Ignore. \n Provided templates should follow the syntax defined
-                      for text/template Go package, see https://pkg.go.dev/text/template.
-                      Annotations inside the template correspond to the definition
-                      of the source resource object (e.g. Kubernetes service, OpenShift
-                      route). Example: \"{{.Name}}.example.com\" would be expanded
-                      to \"myservice.example.com\" for service source"
+                      This field must be specified with a nonempty value if the source
+                      type is Service or CRD and HostnameAnnotationPolicy is set to
+                      Ignore.  The field value may be omitted or empty if HostnameAnnotationPolicy
+                      is set to Allow or if the source type is OpenShiftRoute. \n
+                      Provided templates should follow the syntax defined for text/template
+                      Go package, see https://pkg.go.dev/text/template. Annotations
+                      inside the template correspond to the definition of the source
+                      resource object (e.g. Kubernetes service, OpenShift route).
+                      Example: \"{{.Name}}.example.com\" would be expanded to \"myservice.example.com\"
+                      for service source"
                     items:
                       type: string
                     type: array
@@ -279,10 +282,11 @@ spec:
                     - Allow
                     type: string
                   labelFilter:
-                    description: LabelFilter specifies a label selector used to filter
-                      which source instance resources ExternalDNS publishes records
-                      for. The filter uses label selector semantics against source
-                      resource labels.
+                    description: LabelFilter specifies a label selector for filtering
+                      the objects for which ExternalDNS publishes records. The filter
+                      uses label selector semantics against object labels.  Specifying
+                      a null or empty label selector causes ExternalDNS to publish
+                      records for all objects of the source type resource.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -330,9 +334,10 @@ spec:
                       ingress controller names.
                     properties:
                       routerName:
-                        description: If source is openshift-route then you can pass
-                          the ingress controller name. Based on this name external-dns
-                          will select the respective router.
+                        description: RouterName is the name of a router (AKA ingress
+                          controller) as reported in Route.status.ingress[].routerName.  External-dns
+                          will use the canonical hostname of the router identified
+                          by this name when publishing records for a given route.
                         type: string
                     required:
                     - routerName

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -330,8 +330,8 @@ spec:
                         type: object
                     type: object
                   openshiftRouteOptions:
-                    description: OpenShiftRoute source configuration options for specifying
-                      ingress controller names.
+                    description: OpenShiftRoute describes source configuration options
+                      specific to the routes.route.openshift.io resource.
                     properties:
                       routerName:
                         description: RouterName is the name of a router (AKA ingress


### PR DESCRIPTION
#### CRD: Add missing +'s in kubebuilder tags

* `api/v1alpha1/externaldns_types.go` (`ExternalDNSInfobloxProviderOptions`): Change "kubebuilder:validation:Required" to "+kubebuilder:validation:Required".
* `bundle/manifests/externaldns.olm.openshift.io_crd.yaml`:
* `config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml`: Regenerate.


#### CRD: Fix `HostnameAnnotationPolicy` kubebuilder tag

The `HostnameAnnotationPolicy` field is optional in some cases, and it has the `+optional` tag, so its kubebuilder tag should also indicate that the field is optional.

* `api/v1alpha1/externaldns_types.go` (`ExternalDNSSource`): Replace `+kubebuilder:validation:Required` with `+kubebuilder:validation:Optional`.


#### CRD: Add `+kubebuilder:validation:Optional` tags

Add `+kubebuilder:validation:Optional` tags to all optional fields for consistency.

Before this change, some optional fields had both the `+optional` tag and the `+kubebuilder:validation:Optional` tag, and some fields had only the `+optional` tag.

* `api/v1alpha1/externaldns_types.go` (`ExternalDNSSpec`, `ExternalDNSDomainUnion`, `ExternalDNSProvider`, `ExternalDNSGCPProviderOptions`, `ExternalDNSSourceUnion`, `ExternalDNSCRDSourceOptions`: Add `+kubebuilder:validation:Optional` tags to optional fields.


#### CRD: Improve godoc based on API review

* `api/v1alpha1/externaldns_types.go` (`SecretReference`): Change "expected" to "required".
(`ExternalDNSSource`): Clarify exactly when `FQDNTemplate` must be specified and when it may be omitted.
(`ExternalDNSSourceUnion`): Describe the behavior for a null or empty label selector.
(`ExternalDNSOpenShiftRouteOptions`): Clarify that the router name is reported in route status.
* `bundle/manifests/externaldns.olm.openshift.io_crd.yaml`:
* `config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml`: Regenerate.


#### CRD: Fix grammar error in `OpenShiftRoute` godoc

* `api/v1alpha1/externaldns_types.go` (`ExternalDNSSourceUnion`): Rewrite the godoc as a complete sentence that describes the field in general terms.
* `bundle/manifests/externaldns.olm.openshift.io_crd.yaml`:
* `config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml`: Regenerate.