### PR TITLE
Bug 2041999: inject trusted CA to operand deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
 
 7. Create the `Catalogsource` object:
 
-   ```yaml
+   ```bash
    $ cat <<EOF | oc apply -f -
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
@@ -142,9 +142,13 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
    EOF
    ```
 
-8. Create a subscription object to install the Operator:
-   
-    ```yaml
+8. Create the operator namespace:
+    ```bash
+    oc create namespace external-dns-operator
+    ```
+
+9. Create the `Subscription` object:
+    ```bash
     cat <<EOF | oc apply -f -
     apiVersion: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -158,7 +162,22 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
       sourceNamespace: openshift-marketplace
     EOF
     ```
-    **Note**: You can install the `ExternalDNS` Operator through the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS operator`,  and install it in the `external-dns-operator` namespace.
+
+10. Create the `OperatorGroup` object:
+    ```bash
+    cat <<EOF | oc apply -f -
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: external-dns-operator
+      namespace: external-dns-operator
+    spec:
+      targetNamespaces:
+      - external-dns-operator
+    EOF
+    ```
+
+**Note**: The steps starting from the 8th can be replaced with the following actions in the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS Operator`,  and install it in the `external-dns-operator` namespace.
 
 ### Running end-to-end tests manually
 
@@ -179,3 +198,7 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
    ```sh
    $ make test-e2e
    ```
+
+### Proxy support
+
+[Configuring proxy support for ExternalDNS Operator](./docs/proxy.md)

--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -32,6 +32,7 @@ metadata:
     createdAt: 2021/09/28
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     operatorframework.io/suggested-namespace: external-dns-operator
+    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
   name: external-dns-operator.v0.0.1
   namespace: external-dns-operator
 spec:
@@ -87,6 +88,7 @@ spec:
               - args:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --externaldns-image=$(RELATED_IMAGE_EXTERNAL_DNS)
+                - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
                 env:
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
@@ -94,6 +96,8 @@ spec:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_EXTERNAL_DNS
                   value: k8s.gcr.io/external-dns/external-dns:v0.10.2
+                - name: TRUSTED_CA_CONFIGMAP_NAME
+                  value: ""
                 image: quay.io/openshift/origin-external-dns-operator:latest
                 name: operator
                 ports:

--- a/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/external-dns-operator_rbac.authorization.k8s.io_v1_role.yaml
@@ -9,6 +9,7 @@ rules:
     resources:
       - secrets
       - serviceaccounts
+      - configmaps
     verbs:
       - create
       - delete

--- a/cmd/external-dns-operator/main.go
+++ b/cmd/external-dns-operator/main.go
@@ -43,6 +43,7 @@ func main() {
 	flag.StringVar(&opCfg.OperandNamespace, "operand-namespace", operatorconfig.DefaultOperandNamespace, "The namespace that ExternalDNS containers should run in.")
 	flag.StringVar(&opCfg.ExternalDNSImage, "externaldns-image", operatorconfig.DefaultExternalDNSImage, "The container image used for running ExternalDNS.")
 	flag.StringVar(&opCfg.CertDir, "cert-dir", operatorconfig.DefaultCertDir, "The directory for keys and certificates for serving the webhook.")
+	flag.StringVar(&opCfg.TrustedCAConfigMapName, "trusted-ca-configmap", operatorconfig.DefaultTrustedCAConfigMapName, "The name of the config map containing TLS CA(s) which should be trusted by ExternalDNS containers. PEM encoded file under \"ca-bundle.crt\" key is expected.")
 	flag.BoolVar(&opCfg.EnableWebhook, "enable-webhook", operatorconfig.DefaultEnableWebhook, "Enable the validating webhook server. Defaults to true.")
 	flag.BoolVar(&opCfg.EnablePlatformDetection, "enable-platform-detection", operatorconfig.DefaultEnablePlatformDetection, "Enable the detection of the underlying platform. Defaults to true.")
 	opts := zap.Options{

--- a/config/rbac/extra-roles.yaml
+++ b/config/rbac/extra-roles.yaml
@@ -9,6 +9,7 @@ rules:
     resources:
       - serviceaccounts
       - secrets
+      - configmaps
     verbs:
       - get
       - list

--- a/config/rbac/operator_role.yaml
+++ b/config/rbac/operator_role.yaml
@@ -9,6 +9,7 @@ rules:
     resources:
       - secrets
       - serviceaccounts
+      - configmaps
     verbs:
       - create
       - delete

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,86 @@
+# Configuring proxy support for ExternalDNS Operator
+
+The ExternalDNS Operator can work in an environment with a cluster-wide egress proxy set up. There is some configuration to be done to make the operator aware of the proxy:
+- operator container's environment has to be populated with one (or all) of the following variables: `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`.
+- if the proxy uses some custom TLS certificate authority (CA), it has to be put into a configmap and passed to the operator via the `--trusted-ca-configmap` flag.
+
+The ExternalDNS Operator doesn't need the proxy settings on its own because it doesn't interact with DNS providers. However, it has to propagate the proxy settings and CA certificate down to its operand: the ExternalDNS instance.
+
+## Contents
+
+- [Instructions](#instructions)
+- [OpenShift instructions](#openshift-instructions)
+
+## Instructions
+
+### Proxy settings
+
+#### Operator already running
+
+Set HTTP proxy URLs for the operator's deployment:
+```bash
+kubectl -n external-dns-operator set env deployment/external-dns-operator HTTP_PROXY=http://myproxy.net HTTPS_PROXY=https://myproxy.net NO_PROXY=.cluster.local,.svc
+```
+
+### Custom CA
+
+#### Operator already running
+
+1. Create a configmap containing the PEM-encoded proxy CA certificate in the `external-dns-operator` namespace:
+    ```bash
+    kubectl -n external-dns-operator create configmap trusted-ca --from-file=ca-bundle.crt=/path/to/ca/certificate.pem
+    ```
+
+2. Patch the operator's deployment to reference the configmap created in the previous step:
+    ```bash
+    # "operator" container is patched
+    kubectl -n external-dns-operator patch deployment external-dns-operator --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args/-", "value":"--trusted-ca-configmap=trusted-ca"}]'
+    ```
+
+## OpenShift instructions
+
+If a global proxy is configured on the OpenShift cluster, OLM automatically configures Operators with cluster-wide proxy settings. `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables are added to the ExternalDNS Operator's deployment.
+
+### Custom CA
+
+#### For running operator
+
+1. Create a configmap for the proxy CA certificate in the `external-dns-operator` namespace:
+    ```bash
+    oc -n external-dns-operator create configmap trusted-ca
+    oc -n external-dns-operator label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
+    ```
+
+2. Add `spec.config.env` with the name of the configmap created in the previous step to your subscription created by OperatorHub:
+    ```bash
+    oc -n external-dns-operator patch subscription external-dns-operator --type='json' -p='[{"op": "add", "path": "/spec/config", "value":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}]'
+    ```
+
+#### Manual deployment
+You can use the following steps after the `external-dns-operator` namespace has been created and before the operator deployment has been created.
+
+1. Create a configmap for the proxy CA certificate in the `external-dns-operator` namespace:
+    ```bash
+    oc -n external-dns-operator create configmap trusted-ca
+    oc -n external-dns-operator label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
+    ```
+
+2. Create the `Subscription` object:
+    ```bash
+    cat <<EOF | oc apply -f -
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+        name: external-dns-operator
+        namespace: external-dns-operator
+    spec:
+        channel: alpha
+        name: external-dns-operator
+        source: external-dns-operator
+        sourceNamespace: openshift-marketplace
+        config:
+          env:
+          - name: TRUSTED_CA_CONFIGMAP_NAME
+            value: trusted-ca
+    EOF
+    ```

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -39,6 +40,7 @@ const (
 	DefaultOperandNamespace        = "external-dns"
 	DefaultEnableWebhook           = true
 	DefaultEnablePlatformDetection = true
+	DefaultTrustedCAConfigMapName  = ""
 
 	openshiftKind              = "OpenShiftAPIServer"
 	openshiftResourceGroup     = "operator.openshift.io"
@@ -80,6 +82,9 @@ type Config struct {
 
 	// PlatformStatus is the details about the underlying platform.
 	PlatformStatus *configv1.PlatformStatus
+
+	// TrustedCAConfigMapName is the name of the configmap containing CA bundle to be trusted by ExternalDNS containers.
+	TrustedCAConfigMapName string
 }
 
 // DetectPlatform detects the underlying platform and fills corresponding config fields
@@ -105,6 +110,11 @@ func (c *Config) FillPlatformDetails(ctx context.Context, ctrlClient ctrlclient.
 		c.PlatformStatus = infraConfig.Status.PlatformStatus
 	}
 	return nil
+}
+
+// InjectTrustedCA returns true if the trusted CA needs to be injected into ExternalDNS containers.
+func (c *Config) InjectTrustedCA() bool {
+	return len(strings.TrimSpace(c.TrustedCAConfigMapName)) != 0
 }
 
 // isOCP returns true if the platform is OCP

--- a/pkg/operator/controller/ca-configmap/ca_configmap.go
+++ b/pkg/operator/controller/ca-configmap/ca_configmap.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca_configmap
+
+import (
+	"context"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	controller "github.com/openshift/external-dns-operator/pkg/operator/controller"
+)
+
+// ensureTrustedCAConfigMap ensures that the source configmap has been copied to the operand namespace.
+// Returns the target configmap, a boolean if the target configmap exists, and an error when relevant.
+func (r *reconciler) ensureTrustedCAConfigMap(ctx context.Context) (bool, *corev1.ConfigMap, error) {
+	// get the source configmap
+	srcName := types.NamespacedName{Namespace: r.config.SourceNamespace, Name: r.config.CAConfigMapName}
+	sourceExists, source, err := r.currentTrustedCAConfigMap(ctx, srcName)
+	if err != nil {
+		return false, nil, err
+	} else if !sourceExists {
+		return false, nil, nil
+	}
+
+	// check if the target configmap exists
+	targetName := controller.ExternalDNSDestTrustedCAConfigMapName(r.config.TargetNamespace)
+	targetExists, target, err := r.currentTrustedCAConfigMap(ctx, targetName)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// desired is created from the source
+	desired := desiredTrustedCAConfigMap(source, targetName)
+
+	if !targetExists {
+		// target configmap doesn't exist, create it
+		if err := r.createTrustedCAConfigMap(ctx, desired); err != nil {
+			return false, nil, err
+		}
+		return r.currentTrustedCAConfigMap(ctx, targetName)
+	}
+
+	// target configmap exists, try to update it with the source data
+	if updated, err := r.updateTrustedCAConfigMap(ctx, target, desired); err != nil {
+		return true, target, err
+	} else if updated {
+		return r.currentTrustedCAConfigMap(ctx, targetName)
+	}
+
+	return true, target, nil
+}
+
+// currentTrustedCAConfigMap returns the definition of the configmap object with the given name.
+func (r *reconciler) currentTrustedCAConfigMap(ctx context.Context, name types.NamespacedName) (bool, *corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, name, cm); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, cm, nil
+}
+
+// createTrustedCAConfigMap creates the given configmap.
+func (r *reconciler) createTrustedCAConfigMap(ctx context.Context, cm *corev1.ConfigMap) error {
+	if err := r.client.Create(ctx, cm); err != nil {
+		return err
+	}
+	r.log.Info("created trusted CA configmap", "namespace", cm.Namespace, "name", cm.Name)
+	return nil
+}
+
+// desiredTrustedCAConfigMap returns the desired target configmap.
+func desiredTrustedCAConfigMap(source *corev1.ConfigMap, targetName types.NamespacedName) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName.Name,
+			Namespace: targetName.Namespace,
+		},
+		Data: source.Data,
+	}
+}
+
+// updateTrustedCAConfigMap updates the target configmap with the desired content if update is needed.
+// Returns a boolean indicating whether the configmap was updated, and an error value if any occurred.
+func (r *reconciler) updateTrustedCAConfigMap(ctx context.Context, current, desired *corev1.ConfigMap) (bool, error) {
+	if configMapsEqual(current, desired) {
+		return false, nil
+	}
+	updated := current.DeepCopy()
+	updated.Data = desired.Data
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, err
+	}
+	r.log.Info("updated trusted CA configmap", "namespace", updated.Namespace, "name", updated.Name)
+	return true, nil
+}
+
+// configMapsEqual compares two configMaps. Returns true if
+// the configMaps should be considered equal for the purpose of determining
+// whether an update is necessary, false otherwise.
+func configMapsEqual(a, b *corev1.ConfigMap) bool {
+	return reflect.DeepEqual(a.Data, b.Data)
+}

--- a/pkg/operator/controller/ca-configmap/controller.go
+++ b/pkg/operator/controller/ca-configmap/controller.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca_configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	extdnscontroller "github.com/openshift/external-dns-operator/pkg/operator/controller"
+	ctrlutils "github.com/openshift/external-dns-operator/pkg/operator/controller/utils"
+)
+
+const (
+	controllerName = "ca_configmap_controller"
+)
+
+// Config holds all the things necessary for the controller to run.
+type Config struct {
+	SourceNamespace string
+	TargetNamespace string
+	CAConfigMapName string
+}
+
+type reconciler struct {
+	client client.Client
+	config Config
+	log    logr.Logger
+}
+
+// New creates a new controller that syncs the configmap containing trusted CA(s)
+// between the operator and operand namespaces.
+func New(mgr manager.Manager, config Config) (controller.Controller, error) {
+	log := ctrl.Log.WithName(controllerName)
+
+	reconciler := &reconciler{
+		client: mgr.GetClient(),
+		config: config,
+		log:    log,
+	}
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return nil, err
+	}
+
+	targetToSource := func(o client.Object) []reconcile.Request {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: config.SourceNamespace,
+					Name:      config.CAConfigMapName,
+				},
+			},
+		}
+	}
+
+	// Watch the configmap from the source namespace
+	if err := c.Watch(
+		&source.Kind{Type: &corev1.ConfigMap{}},
+		&handler.EnqueueRequestForObject{},
+		predicate.And(predicate.NewPredicateFuncs(ctrlutils.InNamespace(config.SourceNamespace)), predicate.NewPredicateFuncs(ctrlutils.HasName(config.CAConfigMapName))),
+	); err != nil {
+		return nil, err
+	}
+
+	// Watch the configmap from the target namespace
+	// and enqueue the one from the source namespace
+	if err := c.Watch(
+		&source.Kind{Type: &corev1.ConfigMap{}},
+		handler.EnqueueRequestsFromMapFunc(targetToSource),
+		predicate.And(predicate.NewPredicateFuncs(ctrlutils.InNamespace(config.TargetNamespace)), predicate.NewPredicateFuncs(ctrlutils.HasName(extdnscontroller.ExternalDNSDestTrustedCAConfigMapName("").Name))),
+	); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Reconcile reconciles the configmap from the operand namespace
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := r.log.WithValues("configmap", request.NamespacedName)
+	reqLogger.Info("reconciling trusted CA configmap")
+
+	cm := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, request.NamespacedName, cm); err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("configmap not found; reconciliation will be skipped")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get configmap %q: %w", request.NamespacedName, err)
+	}
+
+	if _, _, err := r.ensureTrustedCAConfigMap(ctx); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to ensure the trusted CA configmap: %w", err)
+	}
+
+	reqLogger.Info("trusted CA configmap is reconciled")
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/operator/controller/ca-configmap/controller_test.go
+++ b/pkg/operator/controller/ca-configmap/controller_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca_configmap
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	test "github.com/openshift/external-dns-operator/pkg/operator/controller/utils/test"
+)
+
+const (
+	testSrcConfigMapName    = "test-trusted-ca"
+	testTargetConfigMapName = "external-dns-trusted-ca"
+)
+
+func TestReconcile(t *testing.T) {
+	managedTypesList := []client.ObjectList{
+		&corev1.ConfigMapList{},
+	}
+	eventWaitTimeout := time.Duration(1 * time.Second)
+
+	testCases := []struct {
+		name            string
+		existingObjects []runtime.Object
+		inputConfig     Config
+		inputRequest    ctrl.Request
+		expectedResult  reconcile.Result
+		expectedEvents  []test.Event
+		errExpected     bool
+	}{
+		{
+			name:            "Bootstrap",
+			existingObjects: []runtime.Object{testSrcConfigMap()},
+			inputConfig:     testConfig(),
+			inputRequest:    testRequest(),
+			expectedResult:  reconcile.Result{},
+			expectedEvents: []test.Event{
+				{
+					EventType: watch.Added,
+					ObjType:   "configmap",
+					NamespacedName: types.NamespacedName{
+						Namespace: test.OperandNamespace,
+						Name:      testTargetConfigMapName,
+					},
+				},
+			},
+		},
+		{
+			name:            "Target configmap drifted",
+			existingObjects: []runtime.Object{testSrcConfigMap(), testDriftedConfigMap()},
+			inputConfig:     testConfig(),
+			inputRequest:    testRequest(),
+			expectedResult:  reconcile.Result{},
+			expectedEvents: []test.Event{
+				{
+					EventType: watch.Modified,
+					ObjType:   "configmap",
+					NamespacedName: types.NamespacedName{
+						Namespace: test.OperandNamespace,
+						Name:      testTargetConfigMapName,
+					},
+				},
+			},
+		},
+		{
+			name:            "Target configmap didn't change",
+			existingObjects: []runtime.Object{testSrcConfigMap(), testTargetConfigMap()},
+			inputConfig:     testConfig(),
+			inputRequest:    testRequest(),
+			expectedResult:  reconcile.Result{},
+		},
+		{
+			name:            "Deleted source configmap",
+			existingObjects: []runtime.Object{},
+			inputConfig:     testConfig(),
+			inputRequest:    testRequest(),
+			expectedResult:  reconcile.Result{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.existingObjects...).Build()
+
+			r := &reconciler{
+				client: cl,
+				config: tc.inputConfig,
+				log:    zap.New(zap.UseDevMode(true)),
+			}
+
+			c := test.NewEventCollector(t, cl, managedTypesList, len(tc.expectedEvents))
+
+			// start watching for events from the types managed by the operator
+			c.Start(context.TODO())
+			defer c.Stop()
+
+			// TEST FUNCTION
+			gotResult, err := r.Reconcile(context.TODO(), tc.inputRequest)
+
+			// error check
+			if err != nil {
+				if !tc.errExpected {
+					t.Fatalf("got unexpected error: %v", err)
+				}
+			} else if tc.errExpected {
+				t.Fatalf("error expected but not received")
+			}
+
+			// result check
+			if !reflect.DeepEqual(gotResult, tc.expectedResult) {
+				t.Fatalf("expected result %v, got %v", tc.expectedResult, gotResult)
+			}
+
+			// collect the events received from Reconcile()
+			collectedEvents := c.Collect(len(tc.expectedEvents), eventWaitTimeout)
+
+			// compare collected and expected events
+			idxExpectedEvents := test.IndexEvents(tc.expectedEvents)
+			idxCollectedEvents := test.IndexEvents(collectedEvents)
+			if diff := cmp.Diff(idxExpectedEvents, idxCollectedEvents); diff != "" {
+				t.Fatalf("found diff between expected and collected events: %s", diff)
+			}
+		})
+	}
+}
+
+func testConfig() Config {
+	return Config{
+		SourceNamespace: test.OperatorNamespace,
+		TargetNamespace: test.OperandNamespace,
+		CAConfigMapName: testSrcConfigMapName,
+	}
+}
+
+func testRequest() ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testSrcConfigMapName,
+			Namespace: test.OperatorNamespace,
+		},
+	}
+}
+
+func testSrcConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSrcConfigMapName,
+			Namespace: test.OperatorNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "---pem encoded certificate---",
+		},
+	}
+}
+
+func testTargetConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTargetConfigMapName,
+			Namespace: test.OperandNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "---pem encoded certificate---",
+		},
+	}
+}
+
+func testDriftedConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTargetConfigMapName,
+			Namespace: test.OperandNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "---pem encoded certificate number 2---",
+		},
+	}
+}

--- a/pkg/operator/controller/externaldns/controller.go
+++ b/pkg/operator/controller/externaldns/controller.go
@@ -47,10 +47,12 @@ type Config struct {
 	Image string
 	// OperatorNamespace is the namespace in which this operator is deployed.
 	OperatorNamespace string
-	// IsOpenShift is the flag which instructs the operator that it runs in OpenShift
+	// IsOpenShift is the flag which instructs the operator that it runs in OpenShift.
 	IsOpenShift bool
-	// PlatformStatus is the details about the underlying platform
+	// PlatformStatus is the details about the underlying platform.
 	PlatformStatus *configv1.PlatformStatus
+	// InjectTrustedCA is the flag which instructs the operator to inject the trusted CA into ExternalDNS containers.
+	InjectTrustedCA bool
 }
 
 // reconciler reconciles an ExternalDNS object.

--- a/pkg/operator/controller/externaldns/credentials-request_test.go
+++ b/pkg/operator/controller/externaldns/credentials-request_test.go
@@ -2,11 +2,7 @@ package externaldnscontroller
 
 import (
 	"context"
-
 	"fmt"
-
-	"github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns/test"
-
 	"reflect"
 	"testing"
 
@@ -23,6 +19,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 	controller "github.com/openshift/external-dns-operator/pkg/operator/controller"
+	"github.com/openshift/external-dns-operator/pkg/operator/controller/utils/test"
 )
 
 func TestEnsureCredentialsRequest(t *testing.T) {
@@ -33,7 +30,7 @@ func TestEnsureCredentialsRequest(t *testing.T) {
 		inputConfig               Config
 		inputRequest              ctrl.Request
 		expectedResult            reconcile.Result
-		expectedEvents            []testEvent
+		expectedEvents            []test.Event
 		errExpected               bool
 		ocpPlatform               bool
 		inputExtDNS               *operatorv1alpha1.ExternalDNS

--- a/pkg/operator/controller/externaldns/service_account_test.go
+++ b/pkg/operator/controller/externaldns/service_account_test.go
@@ -31,7 +31,7 @@ import (
 
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
 	controller "github.com/openshift/external-dns-operator/pkg/operator/controller"
-	"github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns/test"
+	"github.com/openshift/external-dns-operator/pkg/operator/controller/utils/test"
 )
 
 func TestEnsureExternalDNSServiceAccount(t *testing.T) {

--- a/pkg/operator/controller/externaldns/status_test.go
+++ b/pkg/operator/controller/externaldns/status_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
-	"github.com/openshift/external-dns-operator/pkg/operator/controller/externaldns/test"
+	"github.com/openshift/external-dns-operator/pkg/operator/controller/utils/test"
 )
 
 // Option for comparison of conditions : ignore LastTransitionTime

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -68,6 +68,14 @@ func ExternalDNSDestCredentialsSecretName(operandNamespace, extdnsName string) t
 	}
 }
 
+// ExternalDNSDestTrustedCAConfigMapName returns the namespaced name of the destination (operand) trusted CA configmap
+func ExternalDNSDestTrustedCAConfigMapName(operandNamespace string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: operandNamespace,
+		Name:      ExternalDNSBaseName + "-trusted-ca",
+	}
+}
+
 func ExternalDNSCredentialsSourceNamespace(cfg *operatorconfig.Config) string {
 	// TODO: use openshift-config namespace for OpenShift?
 	return cfg.OperatorNamespace

--- a/pkg/operator/controller/utils/predicate.go
+++ b/pkg/operator/controller/utils/predicate.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasName returns a predicate which checks whether an object has the given name.
+func HasName(name string) func(o client.Object) bool {
+	return func(o client.Object) bool {
+		return o.GetName() == name
+	}
+}
+
+// InNamespace returns a predicate which checks whether an object belongs to the given namespace.
+func InNamespace(namespace string) func(o client.Object) bool {
+	return func(o client.Object) bool {
+		return o.GetNamespace() == namespace
+	}
+}

--- a/pkg/operator/controller/utils/predicate_test.go
+++ b/pkg/operator/controller/utils/predicate_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestHasName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputName string
+		secret    client.Object
+		expected  bool
+	}{
+		{
+			name:      "Belongs",
+			inputName: "test",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "Does not belong",
+			inputName: "test",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "othertest",
+					Namespace: "testns",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasName(tc.inputName)(tc.secret); got != tc.expected {
+				t.Errorf("unexpected return value received. expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestInNamespace(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ns       string
+		secret   client.Object
+		expected bool
+	}{
+		{
+			name: "Belongs",
+			ns:   "testns",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Does not belong",
+			ns:   "testns",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "othertestns",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := InNamespace(tc.ns)(tc.secret); got != tc.expected {
+				t.Errorf("unexpected return value received. expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/utils/test/events.go
+++ b/pkg/operator/controller/utils/test/events.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cco "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/openshift/external-dns-operator/api/v1alpha1"
+)
+
+// Event is a simplified representation of the watch event received from the controller runtime client.
+type Event struct {
+	EventType watch.EventType
+	ObjType   string
+	types.NamespacedName
+}
+
+// NewEvent returns an event instance created from the controller runtime's watch event.
+func NewEvent(we watch.Event) Event {
+	te := Event{
+		EventType: we.Type,
+	}
+	switch obj := we.Object.(type) {
+	case *corev1.Secret:
+		te.ObjType = "secret"
+		te.Namespace = obj.Namespace
+		te.Name = obj.Name
+	case *corev1.ConfigMap:
+		te.ObjType = "configmap"
+		te.Namespace = obj.Namespace
+		te.Name = obj.Name
+	case *appsv1.Deployment:
+		te.ObjType = "deployment"
+		te.Namespace = obj.Namespace
+		te.Name = obj.Name
+	case *corev1.ServiceAccount:
+		te.ObjType = "serviceaccount"
+		te.Namespace = obj.Namespace
+		te.Name = obj.Name
+	case *rbacv1.ClusterRole:
+		te.ObjType = "clusterrole"
+		te.Name = obj.Name
+	case *rbacv1.ClusterRoleBinding:
+		te.ObjType = "clusterrolebinding"
+		te.Name = obj.Name
+	case *corev1.Namespace:
+		te.ObjType = "namespace"
+		te.Name = obj.Name
+	case *operatorv1alpha1.ExternalDNS:
+		te.ObjType = "externaldns"
+		te.Name = obj.Name
+	case *cco.CredentialsRequest:
+		te.ObjType = "credentialsrequest"
+		te.Name = obj.Name
+	}
+	return te
+}
+
+// Key returns a key like representation of the event.
+func (e Event) Key() string {
+	return string(e.EventType) + "/" + e.ObjType + "/" + e.Namespace + "/" + e.Name
+}
+
+// EventCollector collects all types of events for the given watch types.
+type EventCollector struct {
+	T          *testing.T
+	Client     client.WithWatch
+	WatchTypes []client.ObjectList
+	Verbose    bool
+	watches    []watch.Interface
+	eventsCh   chan watch.Event
+}
+
+// NewEventCollector returns an instance of the event collector.
+func NewEventCollector(t *testing.T, client client.WithWatch, watchTypes []client.ObjectList, bufSize int) *EventCollector {
+	return &EventCollector{
+		T:          t,
+		Client:     client,
+		WatchTypes: watchTypes,
+		eventsCh:   make(chan watch.Event, bufSize),
+	}
+}
+
+// Start starts watches for all the watch types.
+func (c *EventCollector) Start(ctx context.Context) {
+	c.T.Helper()
+
+	for _, watchType := range c.WatchTypes {
+		w, err := c.Client.Watch(ctx, watchType)
+		if err != nil {
+			c.T.Fatalf("failed to start the watch for %T: %v", watchType, err)
+		}
+		c.watches = append(c.watches, w)
+	}
+
+	// fan in the events
+	for _, w := range c.watches {
+		go func(ch <-chan watch.Event) {
+			for e := range ch {
+				if testing.Verbose() {
+					c.T.Logf("Got watch event: %v", e)
+				}
+				c.eventsCh <- e
+			}
+		}(w.ResultChan())
+	}
+}
+
+// Stop stops all the watches.
+func (c *EventCollector) Stop() {
+	for _, w := range c.watches {
+		w.Stop()
+	}
+}
+
+// Collect collects events until the given number is reached or until the timeout is expired.
+func (c *EventCollector) Collect(num int, timeout time.Duration) []Event {
+	res := []Event{}
+out:
+	for {
+		select {
+		case e := <-c.eventsCh:
+			res = append(res, NewEvent(e))
+			if len(res) == num {
+				break out
+			}
+		case <-time.After(timeout):
+			break out
+		}
+	}
+	return res
+}
+
+// IndexEvents turns the slice of events into a map for the more convenient lookups.
+func IndexEvents(events []Event) map[string]Event {
+	m := map[string]Event{}
+	for _, e := range events {
+		m[e.Key()] = e
+	}
+	return m
+}

--- a/pkg/operator/controller/utils/test/vars.go
+++ b/pkg/operator/controller/utils/test/vars.go
@@ -28,13 +28,15 @@ import (
 )
 
 const (
-	Name                = "test"
-	OperandNamespace    = "external-dns"
-	OperandName         = "external-dns-test"
-	OperandImage        = "quay.io/test/external-dns:latest"
-	PublicZone          = "my-dns-public-zone"
-	PrivateZone         = "my-dns-private-zone"
-	AzurePrivateDNSZone = "/subscriptions/xxxx/resourceGroups/test-az-2f9kj-rg/providers/Microsoft.Network/privateDnsZones/test-az.example.com"
+	Name                   = "test"
+	OperandNamespace       = "external-dns"
+	OperandName            = "external-dns-test"
+	OperandImage           = "quay.io/test/external-dns:latest"
+	OperatorNamespace      = "external-dns-operator"
+	PublicZone             = "my-dns-public-zone"
+	PrivateZone            = "my-dns-private-zone"
+	AzurePrivateDNSZone    = "/subscriptions/xxxx/resourceGroups/test-az-2f9kj-rg/providers/Microsoft.Network/privateDnsZones/test-az.example.com"
+	TrustedCAConfigMapName = "test-trusted-ca"
 )
 
 var (


### PR DESCRIPTION
This PR allows the operator to inject trusted CA(s) into ExternalDNS (operand) containers.

**What's inside**

- New flag to pass the name of the configmap containing the CA (`cmd/external-dns-operator/main.go`)
- New controller to copy this configmap from the operator into the operand namespace (`pkg/operator/controller/ca-configmap/`)
- Updated desired ExternalDNS deployment. Mounts the trusted CA file now (`pkg/operator/controller/externaldns/pod.go`)
- Updated RBAC files (`configmaps` resources)
- New `pkg/operator/controller/utils` package for things used in all the controllers, mainly for `EventCollector` used in all the controllers' tests (`pkg/operator/controller/utils/`, `pkg/operator/controller/utils/test/`) 
- New doc for the proxy support (`docs/proxy.md`)