### PR TITLE
README: ease the command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,128 @@
 # ExternalDNS Operator
 
-The `ExternalDNS` Operator allows you to deploy and manage [ExternalDNS](https://github.com/kubernetes-sigs/external-dns), a cluster-internal component which makes Kubernetes resources discoverable through public DNS servers. \
-**Note**: This Operator is in the early stages of implementation. For more information, see
-[ExternalDNS Operator OpenShift Enhancement Proposal](https://github.com/openshift/enhancements/pull/786).
+The `ExternalDNS` Operator allows you to deploy and manage [ExternalDNS](https://github.com/kubernetes-sigs/external-dns), a cluster-internal component which makes Kubernetes resources discoverable through public DNS servers. For more information about the initial motivation, see [ExternalDNS Operator OpenShift Enhancement Proposal](https://github.com/openshift/enhancements/pull/786).
+
+- [Deploying the ExternalDNS Operator](#deploying-the-externaldns-operator)
+    - [Preparing the environment](#preparing-the-environment)
+    - [Installing the ExternalDNS Operator by building and pushing the Operator image to a registry](#installing-the-externaldns-operator-by-building-and-pushing-the-operator-image-to-a-registry)
+    - [Installing the ExternalDNS Operator using a custom index image on OperatorHub](#installing-the-externaldns-operator-using-a-custom-index-image-on-operatorhub)
+- [Running end-to-end tests manually](#running-end-to-end-tests-manually)
+- [Proxy support](#proxy-support)
 
 ## Deploying the `ExternalDNS` Operator
-The following procedure describes how to deploy the `ExternalDNS` Operator for AWS.
+The following procedure describes how to deploy the `ExternalDNS` Operator for AWS.     
+
+### Preparing the environment
+Prepare your environment for the installation commands. 
+
+- Select the container runtime you want to build the images with (`podman` or `docker`):
+    ```sh
+    export CONTAINER_ENGINE=podman
+    ```
+- Select the name settings of the image:
+    ```sh
+    export REGISTRY=quay.io
+    export REPOSITORY=myuser
+    export VERSION=1.0.0
+    ```
+- Login to the image registry:
+    ```sh
+    ${CONTAINER_ENGINE} login ${REGISTRY} -u ${REPOSITORY}
+    ```
 
 ### Installing the `ExternalDNS` Operator by building and pushing the Operator image to a registry
 1. Build and push the Operator image to a registry:
    ```sh
-   $ export IMG=<registry>/<username>/external-dns-operator:latest
-   $ make image-build
-   $ make image-push
+   export IMG=${REGISTRY}/${REPOSITORY}/external-dns-operator:${VERSION}
+   make image-build image-push
    ```
+
 2. Prepare the operand namespace:
-   ```
-   oc create ns external-dns
-   oc apply -f config/rbac/extra-roles.yaml
+   ```sh
+   kubectl create ns external-dns
+   kubectl apply -f config/rbac/extra-roles.yaml
    ```
 
 3. Run the following command to deploy the `ExternalDNS` Operator:
+    ```sh
+    make deploy
     ```
-    $ make deploy
-    ```
+
 4. The previous step deploys the validation webhook, which requires TLS authentication for the webhook server. The
    manifests deployed through the `make deploy` command do not contain a valid certificate and key. You must provision a valid certificate and key through other tools.
    You can use a convenience script, `hack/generate-certs.sh` to generate the certificate bundle and patch the validation webhook config.   
    _Important_: Do not use the hack/generate-certs.sh script in a production environment.   
    Run the `hack/generate-certs.sh` script with the following inputs:
-   ```bash
-   $ hack/generate-certs.sh --service webhook-service --webhook validating-webhook-configuration \
+   ```sh
+   hack/generate-certs.sh --service webhook-service --webhook validating-webhook-configuration \
    --secret webhook-server-cert --namespace external-dns-operator
    ```
+
 5. Now you can deploy an instance of ExternalDNS:
     * Run the following command to create the credentials secret for AWS:
-        ```bash
-        $ kubectl -n external-dns-operator create secret generic aws-access-key \
+        ```sh
+        kubectl -n external-dns-operator create secret generic aws-access-key \
                 --from-literal=aws_access_key_id=${ACCESS_KEY_ID} \
                 --from-literal=aws_secret_access_key=${ACCESS_SECRET_KEY}
         ```
        *Note*: See [this guide](./docs/usage.md) for instructions specific to other providers.
       
     * Run the following command:
-      ```bash
+      ```sh
       # for AWS
-      $ kubectl apply -k config/samples/aws
+      kubectl apply -k config/samples/aws
       ```
        *Note*: For other providers, see `config/samples/`.
 
 
 ### Installing the `ExternalDNS` Operator using a custom index image on OperatorHub
-**Note**: By default container engine used is docker but you can specify podman by adding CONTAINER_ENGINE=podman to your image build and push commands as mentioned below.
+**Note**: The below procedure works best with `podman` as container engine
     
-1. Build and push the operator image to the registry.
-   
-    a. Select the container runtime you want. Either podman or docker. 
+1. Build and push the operator image to the registry:
     ```sh
-    $ export CONTAINER_ENGINE=podman
+    export IMG=${REGISTRY}/${REPOSITORY}/external-dns-operator:${VERSION}
+    make image-build image-push
     ```
-    b. Set your image name:
-    ```sh
-    $ export IMG=<registry>/<username>/external-dns-operator:latest
-    ```
-    c. Build and push the image:
-    ```sh
-    $ make image-build
-    $ make image-push
-    ```
-   
-2. Build the bundle image.
+
+2. Build and push the bundle image to the registry:
   
-    a. Export your expected image name which shall have your registry name in an env var.
-    ```sh
-    $ export BUNDLE_IMG=<registry>/<username>/external-dns-operator-bundle:latest
-    ```
-    b. In the `bundle/manifests/external-dns-operator_clusterserviceversion.yaml`
+    a. In the `bundle/manifests/external-dns-operator_clusterserviceversion.yaml`
         add the operator image created in Step 1 as follows:
     ```sh
-        In annotations:
-        Change containerImage: quay.io/openshift/origin-external-dns-operator:latest
-        to containerImage: <registry>/<username, repository name>/external-dns-operator:latest
-    
-        In spec:
-        Change image: quay.io/openshift/origin-external-dns-operator:latest
-        to image: <registry>/<username, repository name>/external-dns-operator:latest
+    sed -i "s|quay.io/openshift/origin-external-dns-operator:latest|${IMG}|g" bundle/manifests/external-dns-operator_clusterserviceversion.yaml
     ```
-    c. Build the image
-    ```sh   
-    $ make bundle-image-build
-    ```
-   
-3. Push the bundle image to the registry:
+    b. Build the image
     ```sh
-    $ make bundle-image-push
+    export BUNDLE_IMG=${REGISTRY}/${REPOSITORY}/external-dns-operator-bundle:${VERSION}
+    make bundle-image-build bundle-image-push
     ```
 
-4. Build and push the image index to the registry:
+3. Build and push the index image to the registry:
    ```sh
-   $ export INDEX_IMG=<registry>/<username>/external-dns-operator-bundle-index:1.0.0
-   $ make index-image-build
-   $ make index-image-push
+   export INDEX_IMG=${REGISTRY}/${REPOSITORY}/external-dns-operator-bundle-index:${VERSION}
+   make index-image-build index-image-push
    ```
 
-5. Prepare the operand namespace:
-   ```
+4. Prepare the operand namespace:
+   ```sh
    oc create ns external-dns
    oc apply -f config/rbac/extra-roles.yaml
    ```
 
-6. You may need to link the registry secret to the pod of `external-dns-operator` created in the `openshift-marketplace` namespace if the image is not made public ([Doc link](https://docs.openshift.com/container-platform/4.9/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)). If you are using `podman` then these are the instructions:
+5. You may need to link the registry secret to the pod of `external-dns-operator` created in the `openshift-marketplace` namespace if the image is not made public ([Doc link](https://docs.openshift.com/container-platform/4.9/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)). If you are using `podman` then these are the instructions:
 
-    a. Login to your registry:
+    a. Create a secret with authentication details of your image registry:
     ```sh
-    $ podman login quay.io
+    oc -n openshift-marketplace create secret generic extdns-olm-secret  --type=kubernetes.io/dockercfg  --from-file=.dockercfg=${XDG_RUNTIME_DIR}/containers/auth.json
     ```
-    b. Create a secret with registry auth details:
+    b. Link the secret to `default` service account:
     ```sh
-    $ oc -n openshift-marketplace create secret generic extdns-olm-secret  --type=kubernetes.io/dockercfg  --from-file=.dockercfg=${XDG_RUNTIME_DIR}/containers/auth.json
-    ```
-    c. Link the secret to default and builder service accounts:
-    ```sh
-    $ oc secrets link builder extdns-olm-secret -n openshift-marketplace
-    $ oc secrets link default extdns-olm-secret --for=pull -n openshift-marketplace
+    oc -n openshift-marketplace secrets link default extdns-olm-secret --for=pull
     ````
-    **Note**: the secret to the pod of `external-dns-operator` is part of the bundle created in step 1.
 
-
-7. Create the `Catalogsource` object:
-
-   ```bash
-   $ cat <<EOF | oc apply -f -
+6. Create the `Catalogsource` object:
+   ```sh
+   cat <<EOF | oc apply -f -
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
    metadata:
@@ -138,17 +130,31 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
      namespace: openshift-marketplace
    spec:
      sourceType: grpc
-     image: <registry>/<username>/external-dns-operator-bundle-index:1.0.0
+     image: ${INDEX_IMG}
    EOF
    ```
 
-8. Create the operator namespace:
-    ```bash
+7. Create the operator namespace:
+    ```sh
     oc create namespace external-dns-operator
     ```
 
+8. Create the `OperatorGroup` object to scope the operator to `external-dns-operator` namespace:
+    ```sh
+    cat <<EOF | oc apply -f -
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: external-dns-operator
+      namespace: external-dns-operator
+    spec:
+      targetNamespaces:
+      - external-dns-operator
+    EOF
+    ```
+
 9. Create the `Subscription` object:
-    ```bash
+    ```sh
     cat <<EOF | oc apply -f -
     apiVersion: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -163,23 +169,9 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
     EOF
     ```
 
-10. Create the `OperatorGroup` object:
-    ```bash
-    cat <<EOF | oc apply -f -
-    apiVersion: operators.coreos.com/v1
-    kind: OperatorGroup
-    metadata:
-      name: external-dns-operator
-      namespace: external-dns-operator
-    spec:
-      targetNamespaces:
-      - external-dns-operator
-    EOF
-    ```
+**Note**: The steps starting from the 7th can be replaced with the following actions in the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS Operator`,  and install it in the `external-dns-operator` namespace.
 
-**Note**: The steps starting from the 8th can be replaced with the following actions in the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS Operator`,  and install it in the `external-dns-operator` namespace.
-
-### Running end-to-end tests manually
+## Running end-to-end tests manually
 
 1. Deploy the operator as described above
 
@@ -196,9 +188,9 @@ The following procedure describes how to deploy the `ExternalDNS` Operator for A
 
 3. Run the test suite
    ```sh
-   $ make test-e2e
+   make test-e2e
    ```
 
-### Proxy support
+## Proxy support
 
 [Configuring proxy support for ExternalDNS Operator](./docs/proxy.md)


### PR DESCRIPTION
This PR aims at bringing smoother README experience. The idea is to be able to copy-paste without burden.

That's what I did for this:
- removed `$` from shell commands
- added the preparation of the environment to be able to automate the subsequent commands
- removed some manual steps
- grouped `make` commands

Also, added the contents links.