### PR TITLE
Bug 2049410: make meaningful default CR from Operator webUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Prepare your environment for the installation commands.
     oc -n openshift-marketplace secrets link default extdns-olm-secret --for=pull
     ````
 
-6. Create the `Catalogsource` object:
+6. Create the `CatalogSource` object:
    ```sh
    cat <<EOF | oc apply -f -
    apiVersion: operators.coreos.com/v1alpha1

--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -348,21 +348,18 @@ type ExternalDNSInfobloxProviderOptions struct {
 	// GridHost is the IP of the Infoblox Grid host.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:="127.0.0.1"
 	// +required
 	GridHost string `json:"gridHost"`
 
 	// WAPIPort is the port for the Infoblox WAPI.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:=443
 	// +required
 	WAPIPort int `json:"wapiPort"`
 
 	// WAPIVersion is the version of the Infoblox WAPI.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:="2.3.1"
 	// +required
 	WAPIVersion string `json:"wapiVersion"`
 }

--- a/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator_clusterserviceversion.yaml
@@ -12,15 +12,11 @@ metadata:
           },
           "spec": {
             "provider": {
-              "type": "AWS",
-              "aws": {
-                "credentials": {
-                  "name": "aws-access-key"
-                }
-              }
+              "type": "AWS"
             },
             "source": {
-              "type": "Service"
+              "type": "Service",
+              "fqdnTemplate": ["{{.Name}}.mydomain.com"]
             }
           }
         }

--- a/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_crd.yaml
@@ -209,15 +209,12 @@ spec:
                         - name
                         type: object
                       gridHost:
-                        default: 127.0.0.1
                         description: GridHost is the IP of the Infoblox Grid host.
                         type: string
                       wapiPort:
-                        default: 443
                         description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer
                       wapiVersion:
-                        default: 2.3.1
                         description: WAPIVersion is the version of the Infoblox WAPI.
                         type: string
                     required:

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -211,15 +211,12 @@ spec:
                         - name
                         type: object
                       gridHost:
-                        default: 127.0.0.1
                         description: GridHost is the IP of the Infoblox Grid host.
                         type: string
                       wapiPort:
-                        default: 443
                         description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer
                       wapiVersion:
-                        default: 2.3.1
                         description: WAPIVersion is the version of the Infoblox WAPI.
                         type: string
                     required:


### PR DESCRIPTION
Remove unused defaults in API and change the example from OLM bundle to make the default YAML in WebUI more meaningful.

**Note**: `YAML view` in Operator's WebUI is a merge of what's put into `ALM-example` of CSV manifest and the default values from CRD manifest. `ALM-example` takes precedence and if a certain YAML/JSON path (e.g. `.spec.source`) is set in the example the CRD defaults from this path are not used.
![image](https://user-images.githubusercontent.com/18031474/152503552-d2c59d01-df0f-4b94-afbe-c330f3bf803c.png)

