### PR TITLE
Deploy operands in the operator's namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `ExternalDNS` Operator allows you to deploy and manage [ExternalDNS](https:/
 The following procedure describes how to deploy the `ExternalDNS` Operator for AWS.     
 
 ### Preparing the environment
-Prepare your environment for the installation commands. 
+Prepare your environment for the installation commands.
 
 - Select the container runtime you want to build the images with (`podman` or `docker`):
     ```sh
@@ -37,13 +37,7 @@ Prepare your environment for the installation commands.
    make image-build image-push
    ```
 
-2. Prepare the operand namespace:
-   ```sh
-   kubectl create ns external-dns
-   kubectl apply -f config/rbac/extra-roles.yaml
-   ```
-
-3. You may need to link the registry secret to `external-dns-operator` service account if the image is not public ([Doc link](https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)):
+2. You may need to link the registry secret to `external-dns-operator` service account if the image is not public ([Doc link](https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)):
 
     a. Create a secret with authentication details of your image registry:
     ```sh
@@ -54,12 +48,12 @@ Prepare your environment for the installation commands.
     oc -n external-dns-operator secrets link external-dns-operator extdns-pull-secret --for=pull
     ````
 
-4. Run the following command to deploy the `ExternalDNS` Operator:
+3. Run the following command to deploy the `ExternalDNS` Operator:
     ```sh
     make deploy
     ```
 
-5. The previous step deploys the validation webhook, which requires TLS authentication for the webhook server. The
+4. The previous step deploys the validation webhook, which requires TLS authentication for the webhook server. The
    manifests deployed through the `make deploy` command do not contain a valid certificate and key. You must provision a valid certificate and key through other tools.
    You can use a convenience script, `hack/generate-certs.sh` to generate the certificate bundle and patch the validation webhook config.   
    _Important_: Do not use the hack/generate-certs.sh script in a production environment.   
@@ -69,7 +63,7 @@ Prepare your environment for the installation commands.
    --secret webhook-server-cert --namespace external-dns-operator
    ```
 
-6. Now you can deploy an instance of ExternalDNS:
+5. Now you can deploy an instance of ExternalDNS:
     * Run the following command to create the credentials secret for AWS:
         ```sh
         kubectl -n external-dns-operator create secret generic aws-access-key \
@@ -107,13 +101,7 @@ Prepare your environment for the installation commands.
    make index-image-build index-image-push
    ```
 
-4. Prepare the operand namespace:
-   ```sh
-   oc create ns external-dns
-   oc apply -f config/rbac/extra-roles.yaml
-   ```
-
-5. You may need to link the registry secret to the pod of `external-dns-operator` created in the `openshift-marketplace` namespace if the image is not made public ([Doc link](https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)). If you are using `podman` then these are the instructions:
+4. You may need to link the registry secret to the pod of `external-dns-operator` created in the `openshift-marketplace` namespace if the image is not made public ([Doc link](https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)). If you are using `podman` then these are the instructions:
 
     a. Create a secret with authentication details of your image registry:
     ```sh
@@ -124,7 +112,7 @@ Prepare your environment for the installation commands.
     oc -n openshift-marketplace secrets link default extdns-olm-secret --for=pull
     ````
 
-6. Create the `CatalogSource` object:
+5. Create the `CatalogSource` object:
    ```sh
    cat <<EOF | oc apply -f -
    apiVersion: operators.coreos.com/v1alpha1
@@ -138,12 +126,12 @@ Prepare your environment for the installation commands.
    EOF
    ```
 
-7. Create the operator namespace:
+6. Create the operator namespace:
     ```sh
     oc create namespace external-dns-operator
     ```
 
-8. Create the `OperatorGroup` object to scope the operator to `external-dns-operator` namespace:
+7. Create the `OperatorGroup` object to scope the operator to `external-dns-operator` namespace:
     ```sh
     cat <<EOF | oc apply -f -
     apiVersion: operators.coreos.com/v1
@@ -157,7 +145,7 @@ Prepare your environment for the installation commands.
     EOF
     ```
 
-9. Create the `Subscription` object:
+8. Create the `Subscription` object:
     ```sh
     cat <<EOF | oc apply -f -
     apiVersion: operators.coreos.com/v1alpha1
@@ -173,7 +161,7 @@ Prepare your environment for the installation commands.
     EOF
     ```
 
-**Note**: The steps starting from the 7th can be replaced with the following actions in the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS Operator`,  and install it in the `external-dns-operator` namespace.
+**Note**: The steps starting from the 6th can be replaced with the following actions in the web console: Navigate to  `Operators` -> `OperatorHub`, search for the `ExternalDNS Operator`,  and install it in the `external-dns-operator` namespace.
 
 ## Running end-to-end tests manually
 

--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -332,12 +332,6 @@ spec:
   description: |-
     The ExternalDNS Operator deploys and manages ExternalDNS, which dynamically manages DNS records in external DNS Providers for specific Kubernetes resources.
 
-    ## Prerequisites and Requirements
-     The ExternalDNS Operator has minimal cluster level permissions. Unfortunately OLM doesn't allow the local role creation in the operand namespace yet.
-     Therefore make sure the following commands are run against your cluster before the installation of the operator:
-     * Create the operand namespace: `oc create ns external-dns`
-     * Grant the operator access to manage operand resources: `oc apply -f https://raw.githubusercontent.com/openshift/external-dns-operator/main/config/rbac/extra-roles.yaml`
-
     ## How it works
      Follow this link to get an idea of how ExternalDNS Operator works: [flow diagram](https://raw.githubusercontent.com/openshift/external-dns-operator/main/docs/images/external-dns-flow-openshift.png).
   displayName: ExternalDNS Operator
@@ -435,6 +429,7 @@ spec:
               - args:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --operator-namespace=$(OPERATOR_NAMESPACE)
+                - --operand-namespace=$(OPERATOR_NAMESPACE)
                 - --externaldns-image=$(RELATED_IMAGE_EXTERNAL_DNS)
                 - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
                 env:

--- a/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -11,3 +11,6 @@ subjects:
 - kind: Group
   name: system:serviceaccounts:external-dns
   namespace: external-dns
+- kind: Group
+  name: system:serviceaccounts:external-dns-operator
+  namespace: external-dns-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,7 @@ spec:
         args:
         - --metrics-bind-address=127.0.0.1:8080
         - --operator-namespace=$(OPERATOR_NAMESPACE)
+        - --operand-namespace=$(OPERATOR_NAMESPACE)
         - --externaldns-image=$(RELATED_IMAGE_EXTERNAL_DNS)
         - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
         env:

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -34,12 +34,6 @@ spec:
   description: |-
     The ExternalDNS Operator deploys and manages ExternalDNS, which dynamically manages DNS records in external DNS Providers for specific Kubernetes resources.
 
-    ## Prerequisites and Requirements
-     The ExternalDNS Operator has minimal cluster level permissions. Unfortunately OLM doesn't allow the local role creation in the operand namespace yet.
-     Therefore make sure the following commands are run against your cluster before the installation of the operator:
-     * Create the operand namespace: `oc create ns external-dns`
-     * Grant the operator access to manage operand resources: `oc apply -f https://raw.githubusercontent.com/openshift/external-dns-operator/main/config/rbac/extra-roles.yaml`
-
     ## How it works
      Follow this link to get an idea of how ExternalDNS Operator works: [flow diagram](https://raw.githubusercontent.com/openshift/external-dns-operator/main/docs/images/external-dns-flow-openshift.png).
   displayName: ExternalDNS Operator

--- a/config/rbac/operand_rolebinding.yaml
+++ b/config/rbac/operand_rolebinding.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: system:serviceaccounts:external-dns
     namespace: external-dns
+  - kind: Group
+    name: system:serviceaccounts:external-dns-operator
+    namespace: external-dns-operator

--- a/docs/design/separate-operand-namespace.md
+++ b/docs/design/separate-operand-namespace.md
@@ -1,0 +1,35 @@
+# Using ExternalDNS Operator with the operands in a separate namespace
+The ExternalDNS Operator deploys operands in its own namespace (`external-dns-operator` by default). This deployment model fits well the opinionated OLM design.
+However ExternalDNS Operator was initially designed similar to the other cluster level operators which often deploy their operands in a separate namespace.
+Even though the old model is **not** officially supported, technically the operator is still capable of working with the operands residing in a different namespace.
+
+## WHYs
+Why you may want to deploy operands in a separate namespace?
+- Easy clean-up of the operands: they can be removed without the risk of touching the operator
+- Safe operator namespace removal, risk of a deadlocked namespace. Not quite applicable for the cluster level CRs but still worth a mention:
+    - Race between the removals of the operand and the operator which may still receive a webhook for the delete event
+    - Race between the removals of the CR which needs to be finalized and the operator which does the finalization
+
+## Deployment
+- Remove `--operand-namespace` flag from the `args` of `external-dns-operator` container [here](../../config/manager/manager.yaml)
+- Update OLM bundle manifests using `make bundle` command if you plan to install via Operator Hub
+- Create the operand namespace and extra RBAC:
+    ```sh
+    kubectl create ns external-dns
+    kubectl apply -f config/rbac/extra-roles.yaml
+    ```
+- Follow [README](../../README.md) instructions to install the operator
+
+## End to end test
+- Instruct the e2e test to ensure the operand resources:
+    ```sh
+    export E2E_SEPARATE_OPERAND_NAMESPACE=true
+    ```
+- Follow [README](../../README.md) instructions to run the e2e test
+
+## Technical debt
+The ExternalDNS Operator was migrated to the model with the single namespace for the operator and the operands when it was already mature.  
+This left some technical decisions which are not strictly necessary anymore. Here is the evolving list of them:
+- Dedicated controllers for the credentials secret and trusted CA configmap
+    - Copy of the secret and the configmap from the operator namespace into the operand's one doesn't need to be made anymore
+- `--operand-namespace` flag

--- a/docs/migration-guides.md
+++ b/docs/migration-guides.md
@@ -1,0 +1,22 @@
+# Migration guides
+
+## From 0.1.x (TechPreview) to 1.0.x (GA)
+
+Features to consider:
+- Operands are deployed in the operator namespace (`external-dns-operator` by default)
+
+### Steps
+The below steps are designed to provide the migration without the service interruption (DNS records will be preserved):
+
+- Remove `external-dns` namespace to prevent multiple ExternalDNS instances from managing the same records
+    ```sh
+    oc delete namespace external-dns
+    ```
+- Upgrade the operator to the new version
+- Check out `external-dns-operator` namespace, it's supposed to have the operands:
+    ```sh
+    oc -n external-dns-operator get pods
+    NAME                                         READY   STATUS    RESTARTS   AGE
+    external-dns-operator-64f885498c-75djt       2/2     Running   0          5m
+    external-dns-sample-aws-5c6cdc5dd8-tpvmx     1/1     Running   0          2m
+    ```


### PR DESCRIPTION
Operand can be deployed in the operator namespace:
```
$ oc -n external-dns-operator get pods
NAME                                     READY   STATUS    RESTARTS   AGE
external-dns-operator-6644944b64-2txst   2/2     Running   0          2m12s

$ oc get ns external-dns
Error from server (NotFound): namespaces "external-dns" not found

$ oc apply -f infoblox-cr.yaml 
externaldns.externaldns.olm.openshift.io/sample-infoblox created

$ oc -n external-dns-operator get pods
NAME                                            READY   STATUS    RESTARTS   AGE
external-dns-operator-6644944b64-2txst          2/2     Running   0          3m40s
external-dns-sample-infoblox-57f97c7849-q2rp9   1/1     Running   0          59s

$ oc get externaldns 
NAME              AGE
sample-infoblox   68s

$ oc -n external-dns-operator logs external-dns-sample-infoblox-57f97c7849-q2rp9
...
time="2022-04-11T20:55:57Z" level=info msg="Created OpenShift client https://10.217.4.1:443"
time="2022-04-11T20:56:08Z" level=debug msg="fetched 0 records from infoblox"
...
time="2022-04-11T20:56:08Z" level=info msg="All records are already up to date"
```

Removal of the CR and the operator namespace works with no problem:
```
$ oc delete externaldns sample-infoblox
externaldns.externaldns.olm.openshift.io "sample-infoblox" deleted

$ oc -n external-dns-operator get pods
NAME                                     READY   STATUS    RESTARTS   AGE
external-dns-operator-6644944b64-2txst   2/2     Running   0          8m24s

$ oc delete ns external-dns-operator
namespace "external-dns-operator" deleted

$ oc get ns external-dns-operator
Error from server (NotFound): namespaces "external-dns-operator" not found
```

Even if there is a CR and an operand the namespace can be removed - no problem:
```
$ oc -n external-dns-operator get pods
NAME                                            READY   STATUS    RESTARTS   AGE
external-dns-operator-6cf8d8576d-r9drk          2/2     Running   0          34s
external-dns-sample-infoblox-57f97c7849-rztbw   1/1     Running   0          11s

$ oc get externaldns
NAME              AGE
sample-infoblox   18s

$ oc delete ns external-dns-operator
namespace "external-dns-operator" deleted

$ oc get externaldns
NAME              AGE
sample-infoblox   41s
```