### PR TITLE
use public golang 1.17 for the local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+FROM golang:1.17:latest as builder
 
 WORKDIR /opt/app-root/src
 COPY . .


### PR DESCRIPTION
Why this change?

- The base image from `Dockerfile` is used for the local builds only. CI and CPaaS (product release) use RHEL based go 1.17 images for the builds and runtime.
- `ubi8/go-toolset` is slow in its release cycle, `1.17` is still not in the latest image while `1.18` is already out for more than a month. It took them 8 month ([tags dates](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1), [1.16 releases](https://go.dev/doc/devel/release#go1.16)) to release the first `1.16` version, so I don't expect this to be any faster for `1.17`.
