### PR TITLE
rbac: remove operand cluster permissions

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -165,17 +165,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - ""
-          resources:
-          - endpoints
-          - nodes
-          - pods
-          - services
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - cloudcredential.openshift.io
           resources:
           - credentialsrequests
@@ -223,14 +212,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - ingresses
-          verbs:
-          - get
-          - list
-          - watch
         - apiGroups:
           - route.openshift.io
           resources:
@@ -343,6 +324,14 @@ spec:
           - get
           - list
           - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
           - watch
         serviceAccountName: external-dns-operator
     strategy: deployment

--- a/config/rbac/extra-roles.yaml
+++ b/config/rbac/extra-roles.yaml
@@ -21,6 +21,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - pods
     verbs:
       - get
       - list

--- a/config/rbac/operator_role.yaml
+++ b/config/rbac/operator_role.yaml
@@ -28,3 +28,11 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,17 +7,6 @@ metadata:
   name: external-dns-operator
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - nodes
-  - pods
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - cloudcredential.openshift.io
   resources:
   - credentialsrequests
@@ -65,14 +54,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -61,8 +61,6 @@ type Operator struct {
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=externaldns.olm.openshift.io,resources=externaldnses/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=services;endpoints;pods;nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cloudcredential.openshift.io,resources=credentialsrequests;credentialsrequests/status;credentialsrequests/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;watch;list
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch


### PR DESCRIPTION
The operator doesn't create the operand's cluster role anymore, so it doesn't need the permissions required for the functioning operand.