### PR TITLE
trusted CA: add checksum annotation to deployment

### DIFF
--- a/pkg/operator/controller/utils/test/vars.go
+++ b/pkg/operator/controller/utils/test/vars.go
@@ -37,7 +37,7 @@ const (
 	PublicZone             = "my-dns-public-zone"
 	PrivateZone            = "my-dns-private-zone"
 	AzurePrivateDNSZone    = "/subscriptions/xxxx/resourceGroups/test-az-2f9kj-rg/providers/Microsoft.Network/privateDnsZones/test-az.example.com"
-	TrustedCAConfigMapName = "test-trusted-ca"
+	TrustedCAConfigMapName = "external-dns-trusted-ca"
 )
 
 var (


### PR DESCRIPTION
Handle the rotation of the trusted CA using an annotation on the deployment with the configmap's checksum.