### PR TITLE
Update the operand image to catch up on 2 upstream fixes

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -442,7 +442,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_EXTERNAL_DNS
-                  value: quay.io/openshift/origin-external-dns@sha256:419ae8594ba87f197c49e298ecec85e185ed29e8fd80e874351415c7ce69381e
+                  value: quay.io/openshift/origin-external-dns@sha256:76aadc154cd7afc512699c86e6df7c9d1da37195fb8fb64b74fb539b94e5a169
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: quay.io/openshift/origin-external-dns-operator:latest
                 name: external-dns-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,8 +44,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_EXTERNAL_DNS
-          # openshift/external-dns commit: 7511ef28574ef86581fef28e67b95af3b0d97ea9
-          value: quay.io/openshift/origin-external-dns@sha256:419ae8594ba87f197c49e298ecec85e185ed29e8fd80e874351415c7ce69381e
+          # openshift/external-dns commit: 906ba04e06b8d18857bb0f13d2cd5e10843da08e
+          value: quay.io/openshift/origin-external-dns@sha256:76aadc154cd7afc512699c86e6df7c9d1da37195fb8fb64b74fb539b94e5a169
         - name: TRUSTED_CA_CONFIGMAP_NAME
         securityContext:
           capabilities:


### PR DESCRIPTION
Upstream fixes:
- https://github.com/kubernetes-sigs/external-dns/pull/2811
- https://github.com/kubernetes-sigs/external-dns/pull/2913