### PR TITLE
OCPBUGS-819: Azure provider - add wildcard replacement for TXT records

### DIFF
--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -449,6 +449,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 							"--azure-config-file=/etc/kubernetes/azure.json",
 						},
 						VolumeMounts: []corev1.VolumeMount{
@@ -528,6 +529,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--fqdn-template={{.Name}}.test.com",
 							"--azure-config-file=/etc/kubernetes/azure.json",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -588,6 +590,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Capabilities: &corev1.Capabilities{
@@ -657,6 +660,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 							"--azure-config-file=/etc/kubernetes/azure.json",
 						},
 						VolumeMounts: []corev1.VolumeMount{
@@ -697,6 +701,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--ignore-hostname-annotation",
 							"--fqdn-template={{.Name}}.test.com",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 							"--azure-config-file=/etc/kubernetes/azure.json",
 						},
 						VolumeMounts: []corev1.VolumeMount{
@@ -1828,6 +1833,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							`--fqdn-template={{""}}`,
 							"--azure-config-file=/etc/kubernetes/azure.json",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -1883,6 +1889,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							"--ignore-hostname-annotation",
 							`--fqdn-template={{""}}`,
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						SecurityContext: &corev1.SecurityContext{
 							Capabilities: &corev1.Capabilities{
@@ -1948,6 +1955,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							`--fqdn-template={{""}}`,
 							"--azure-config-file=/etc/kubernetes/azure.json",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -1983,6 +1991,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 							`--fqdn-template={{""}}`,
 							"--azure-config-file=/etc/kubernetes/azure.json",
 							"--txt-prefix=external-dns-",
+							"--txt-wildcard-replacement=any",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/pkg/operator/controller/externaldns/pod.go
+++ b/pkg/operator/controller/externaldns/pod.go
@@ -35,19 +35,20 @@ import (
 )
 
 const (
-	defaultMetricsAddress    = "127.0.0.1"
-	defaultOwnerPrefix       = "external-dns"
-	defaultMetricsStartPort  = 7979
-	defaultConfigMountPath   = "/etc/kubernetes"
-	defaultTXTRecordPrefix   = "external-dns-"
-	providerArg              = "--provider="
-	httpProxyEnvVar          = "HTTP_PROXY"
-	httpsProxyEnvVar         = "HTTPS_PROXY"
-	noProxyEnvVar            = "NO_PROXY"
-	trustedCAVolumeName      = "trusted-ca"
-	trustedCAFileName        = "tls-ca-bundle.pem"
-	trustedCAFileKey         = "ca-bundle.crt"
-	trustedCAExtractedPEMDir = "/etc/pki/ca-trust/extracted/pem"
+	defaultMetricsAddress         = "127.0.0.1"
+	defaultOwnerPrefix            = "external-dns"
+	defaultMetricsStartPort       = 7979
+	defaultConfigMountPath        = "/etc/kubernetes"
+	defaultTXTRecordPrefix        = "external-dns-"
+	defaultTXTWildcardReplacement = "any"
+	providerArg                   = "--provider="
+	httpProxyEnvVar               = "HTTP_PROXY"
+	httpsProxyEnvVar              = "HTTPS_PROXY"
+	noProxyEnvVar                 = "NO_PROXY"
+	trustedCAVolumeName           = "trusted-ca"
+	trustedCAFileName             = "tls-ca-bundle.pem"
+	trustedCAFileKey              = "ca-bundle.crt"
+	trustedCAExtractedPEMDir      = "/etc/pki/ca-trust/extracted/pem"
 	// RHEL path for the trusted certificate bundle may not work for some distributions (e.g. Alpine).
 	// This makes the usage of the trusted CAs impossible when the vanilla upstream image is given.
 	// SSL_CERT_DIR allows Golang's crypto library to override the default locations.
@@ -362,6 +363,9 @@ func (b *externalDNSContainerBuilder) fillAWSFields(container *corev1.Container)
 func (b *externalDNSContainerBuilder) fillAzureFields(zone string, container *corev1.Container) {
 	// https://github.com/kubernetes-sigs/external-dns/issues/2082
 	container.Args = addTXTPrefixFlag(container.Args)
+
+	// https://github.com/kubernetes-sigs/external-dns/issues/2922
+	container.Args = append(container.Args, fmt.Sprintf("--txt-wildcard-replacement=%s", defaultTXTWildcardReplacement))
 
 	// check the zone field for the keyword 'privatednszones', this ensures that the
 	// provider 'azure-private-dns' is passed to the container


### PR DESCRIPTION
Since the addition of the new format of TXT records in external-dns `0.12.0` the TXT records are prepended with the type of the DNS record which doesn't comply with the standards of Azure DNS in case of the wildcards: the wildcard symbol (`*`) has to be the leftmost one.

Related issue: https://github.com/kubernetes-sigs/external-dns/issues/2922