### PR TITLE
CFE-611: use dedicated quay.io organization for operand image

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -442,7 +442,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_EXTERNAL_DNS
-                  value: quay.io/openshift/origin-external-dns@sha256:76aadc154cd7afc512699c86e6df7c9d1da37195fb8fb64b74fb539b94e5a169
+                  value: quay.io/external-dns-operator/external-dns@sha256:61dda6375596a8afe26b7bc109fe463e99c8216c8ea9d2475d0d77bcbc721b1e
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: quay.io/openshift/origin-external-dns-operator:latest
                 name: external-dns-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,7 +45,7 @@ spec:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_EXTERNAL_DNS
           # openshift/external-dns commit: 906ba04e06b8d18857bb0f13d2cd5e10843da08e
-          value: quay.io/openshift/origin-external-dns@sha256:76aadc154cd7afc512699c86e6df7c9d1da37195fb8fb64b74fb539b94e5a169
+          value: quay.io/external-dns-operator/external-dns@sha256:61dda6375596a8afe26b7bc109fe463e99c8216c8ea9d2475d0d77bcbc721b1e
         - name: TRUSTED_CA_CONFIGMAP_NAME
         securityContext:
           capabilities:

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	DefaultExternalDNSImage        = "quay.io/openshift/origin-external-dns:latest"
+	DefaultExternalDNSImage        = "quay.io/external-dns-operator/external-dns:latest"
 	DefaultMetricsAddr             = "127.0.0.1:8080"
 	DefaultOperatorNamespace       = "external-dns-operator"
 	DefaultOperandNamespace        = "external-dns"


### PR DESCRIPTION
The operand image built in [openshift/external-dns](https://github.com/openshift/external-dns) repository is now mirrored to the dedicated quay.io organization. This breaks the dependency on the openshift quay.io organization therefore unlocking the potential for a different life cycle.