### PR TITLE
CFE-615: release 1.1: add stable-v1.1 and stable-v1 channels

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -5,8 +5,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=external-dns-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1.0
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.0,stable-v1.1,stable-v1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
 
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 1.0.0
+BUNDLE_VERSION ?= 1.1.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Prepare your environment for the installation commands.
       name: external-dns-operator
       namespace: external-dns-operator
     spec:
-      channel: stable-v1.0
+      channel: stable-v1
       name: external-dns-operator
       source: external-dns-operator
       sourceNamespace: openshift-marketplace

--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -303,14 +303,14 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
-    olm.skipRange: <1.0.0
+    olm.skipRange: <1.1.0
     operatorframework.io/suggested-namespace: external-dns-operator
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
-  name: external-dns-operator.v1.0.0
+  name: external-dns-operator.v1.1.0
   namespace: external-dns-operator
 spec:
   apiservicedefinitions: {}
@@ -587,7 +587,7 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: Red Hat, Inc.
-  version: 1.0.0
+  version: 1.1.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,8 +3,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: "manifests/"
   operators.operatorframework.io.bundle.metadata.v1: "metadata/"
   operators.operatorframework.io.bundle.package.v1: "external-dns-operator"
-  operators.operatorframework.io.bundle.channels.v1: "stable-v1.0"
-  operators.operatorframework.io.bundle.channel.default.v1: "stable-v1.0"
+  operators.operatorframework.io.bundle.channels.v1: "stable-v1.0,stable-v1.1,stable-v1"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable-v1"
   # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
   com.redhat.delivery.backport: false
   # this is a bundle image and should be delivered via an index image

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -7,12 +7,12 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
-    olm.skipRange: <1.0.0
+    olm.skipRange: <1.1.0
     operatorframework.io/suggested-namespace: external-dns-operator
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
-  name: external-dns-operator.v1.0.0
+  name: external-dns-operator.v1.1.0
   namespace: external-dns-operator
 spec:
   apiservicedefinitions: {}
@@ -66,4 +66,4 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: Red Hat, Inc.
-  version: 1.0.0
+  version: 1.1.0

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -75,7 +75,7 @@ You can use the following steps after the `external-dns-operator` namespace has 
         name: external-dns-operator
         namespace: external-dns-operator
     spec:
-        channel: stable-v1.0
+        channel: stable-v1
         name: external-dns-operator
         source: external-dns-operator
         sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This PR adds the new channels:

- `stable-v1.1` for the upcoming release
- `stable-v1` for the users ready to streamline the minor version upgrades

`stable-v1` channel would allow the engineering to reduce the configuration burden too as the channel needs to be mentioned in all the docs and the Prow CI configuration.
`stable-v1.0` is kept in `main` for the moment to not break CI as it uses `stable-v1.0` channel to install the operator. A follow-up PR will need to be done to remove it.