### PR TITLE
OCPBUGS-3630: deployment: enforce recreate strategy to avoid conflicts during upgrades

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-GOLANGCI_VERSION="1.50.0"
+GOLANGCI_VERSION="1.51.2"
 
 OUTPUT_PATH=${1:-./bin/golangci-lint}
 
@@ -10,10 +10,10 @@ GOARCH=$(go env GOARCH)
 
 case $GOOS in
   linux)
-    CHECKSUM="b4b329efcd913082c87d0e9606711ecb57415b5e6ddf233fde9e76c69d9b4e8b"
+    CHECKSUM="4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b"
     ;;
   darwin)
-    CHECKSUM="7ab306b91b0f2bb741cc0a4c86f29f69506eb7b505f47e91b0e74365e4c28c4e"
+    CHECKSUM="0549cbaa2df451cf3a2011a9d73a9cb127784d26749d9cd14c9f4818af104d44"
     ;;
     *)
     echo "Unsupported OS $GOOS"


### PR DESCRIPTION
As per the upstream update: https://github.com/kubernetes-sigs/external-dns/pull/2772. ExternalDNS is currently unable of handling multiple parallel instances (no leader election implemented). This may result into split brain situation during the rolling upgrades.
 