### PR TITLE
OCPBUGS-2793: deployment - remove unsolicited containers

### DIFF
--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -2878,7 +2878,10 @@ func TestExternalDNSDeploymentChanged(t *testing.T) {
 			mutate: func(depl *appsv1.Deployment) {
 				depl.Spec.Template.Spec.Containers = []corev1.Container{testContainer()}
 			},
-			expect: false,
+			expect: true,
+			expectedDeployment: testDeploymentWithContainers([]corev1.Container{
+				testContainer(),
+			}),
 		},
 		{
 			description: "if externalDNS annotation changes",
@@ -3674,7 +3677,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 								},
 								Containers: []corev1.Container{
 									{
-										Name:  "external-dns-injected",
+										Name:  "external-dns-unsolicited",
 										Image: test.OperandImage,
 									},
 								},
@@ -3745,10 +3748,6 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 								},
 							},
 							Containers: []corev1.Container{
-								{
-									Name:  "external-dns-injected",
-									Image: test.OperandImage,
-								},
 								{
 									Name:  ExternalDNSContainerName,
 									Image: test.OperandImage,
@@ -4301,11 +4300,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 								},
 								Containers: []corev1.Container{
 									{
-										Name:  "external-dns-injected-1",
+										Name:  "external-dns-unsolicited-1",
 										Image: test.OperandImage,
 									},
 									{
-										Name:  "external-dns-injected-2",
+										Name:  "external-dns-unsolicited-2",
 										Image: test.OperandImage,
 									},
 								},
@@ -4376,14 +4375,6 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 								},
 							},
 							Containers: []corev1.Container{
-								{
-									Name:  "external-dns-injected-1",
-									Image: test.OperandImage,
-								},
-								{
-									Name:  "external-dns-injected-2",
-									Image: test.OperandImage,
-								},
 								{
 									Name:  ExternalDNSContainerName,
 									Image: test.OperandImage,


### PR DESCRIPTION
[Previous PR](https://github.com/openshift/external-dns-operator/pull/176) for the same ticket introduced a new bug: unsolicited containers from the previous states of ExternalDNS CR are kept. The bug was caught by @lihongan and has [this visible consequence](https://issues.redhat.com/browse/OCPBUGS-2793?focusedCommentId=21361960&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21361960) when the zone ID (`ExternalDNS.spec.zones`) of an existing instance of ExternalDNS is changed.

**Bad case scenario**:
- ExternalDNS CR has 1 zone ID specified: `x.y.z`
- Operator already spawned a deployment for this instance. This deployment has one single container named `external-dns-<hash-for-zone-x-y-z>` (note that for each zone ID specified the operator creates a dedicated container in the deployment)
- User changes the zone ID in ExternalDNS from `x.y.z` to `y.y.y`
- Operator reacts to the change and generates the desired state deployment with a single container named: `external-dns-<hash-for-zone-y-y-y>`
- Since unsolicited containers are allowed the container named `external-dns-<hash-for-zone-x-y-z>` from the current deployment is not removed

**Impact**:
- Old container has a conflict on the metrics address: fails to bind on the same port
- User doesn't want to sync DNS records for the old zone anymore: the container should not be there

**Solution**:
At first the idea was to discard the containers from the previous state judging by their name (`external-dns-<hash>`). However the idea of being stricter until a real use case comes up dominated. So all the unsolicited containers are now removed from the managed deployment.