### PR TITLE
NE-1362: External DNS should honor ingress type

### DIFF
--- a/api/v1alpha1/externaldns_types.go
+++ b/api/v1alpha1/externaldns_types.go
@@ -468,13 +468,14 @@ type ExternalDNSSourceUnion struct {
 	OpenShiftRoute *ExternalDNSOpenShiftRouteOptions `json:"openshiftRouteOptions,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=OpenShiftRoute;Service;CRD
+// +kubebuilder:validation:Enum=OpenShiftRoute;Service;CRD;Ingress
 type ExternalDNSSourceType string
 
 const (
 	SourceTypeRoute   ExternalDNSSourceType = "OpenShiftRoute"
 	SourceTypeService ExternalDNSSourceType = "Service"
 	SourceTypeCRD     ExternalDNSSourceType = "CRD"
+	SourceTypeIngress ExternalDNSSourceType = "Ingress"
 )
 
 // +kubebuilder:validation:Enum=Ignore;Allow

--- a/api/v1alpha1/externaldns_webhook.go
+++ b/api/v1alpha1/externaldns_webhook.go
@@ -98,8 +98,8 @@ func (r *ExternalDNS) validateFilters() error {
 }
 
 func (r *ExternalDNS) validateHostnameAnnotationPolicy() error {
-	if r.Spec.Source.Type == SourceTypeRoute {
-		// dummy fqdnTemplate is used for Route source
+	if r.Spec.Source.Type == SourceTypeRoute || r.Spec.Source.Type == SourceTypeIngress {
+		// dummy fqdnTemplate is used for Route source and Ingress
 		return nil
 	}
 

--- a/api/v1beta1/externaldns_types.go
+++ b/api/v1beta1/externaldns_types.go
@@ -468,13 +468,14 @@ type ExternalDNSSourceUnion struct {
 	OpenShiftRoute *ExternalDNSOpenShiftRouteOptions `json:"openshiftRouteOptions,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=OpenShiftRoute;Service;CRD
+// +kubebuilder:validation:Enum=OpenShiftRoute;Service;CRD;Ingress
 type ExternalDNSSourceType string
 
 const (
 	SourceTypeRoute   ExternalDNSSourceType = "OpenShiftRoute"
 	SourceTypeService ExternalDNSSourceType = "Service"
 	SourceTypeCRD     ExternalDNSSourceType = "CRD"
+	SourceTypeIngress ExternalDNSSourceType = "Ingress"
 )
 
 // +kubebuilder:validation:Enum=Ignore;Allow

--- a/api/v1beta1/externaldns_webhook.go
+++ b/api/v1beta1/externaldns_webhook.go
@@ -115,8 +115,8 @@ func (r *ExternalDNS) validateFilters() error {
 }
 
 func (r *ExternalDNS) validateHostnameAnnotationPolicy() error {
-	if r.Spec.Source.Type == SourceTypeRoute {
-		// dummy fqdnTemplate is used for Route source
+	if r.Spec.Source.Type == SourceTypeRoute || r.Spec.Source.Type == SourceTypeIngress {
+		// dummy fqdnTemplate is used for Route source and Ingress
 		return nil
 	}
 

--- a/pkg/operator/controller/externaldns/deployment.go
+++ b/pkg/operator/controller/externaldns/deployment.go
@@ -72,6 +72,7 @@ var providerStringTable = map[operatorv1beta1.ExternalDNSProviderType]string{
 var sourceStringTable = map[operatorv1beta1.ExternalDNSSourceType]string{
 	operatorv1beta1.SourceTypeRoute:   "openshift-route",
 	operatorv1beta1.SourceTypeService: "service",
+	operatorv1beta1.SourceTypeIngress: "ingress",
 }
 
 type deploymentConfig struct {

--- a/pkg/operator/controller/externaldns/pod.go
+++ b/pkg/operator/controller/externaldns/pod.go
@@ -201,7 +201,7 @@ func (b *externalDNSContainerBuilder) fillProviderAgnosticFields(seq int, zone s
 		// However it doesn't make much sense as the hostname is retrieved from the route's spec.
 		// Feeding ExternalDNS with some dummy template just to pass the validation.
 		if b.externalDNS.Spec.Source.HostnameAnnotationPolicy == operatorv1beta1.HostnameAnnotationPolicyIgnore &&
-			b.externalDNS.Spec.Source.Type == operatorv1beta1.SourceTypeRoute {
+			(b.externalDNS.Spec.Source.Type == operatorv1beta1.SourceTypeRoute || b.externalDNS.Spec.Source.Type == operatorv1beta1.SourceTypeIngress) {
 			args = append(args, "--fqdn-template={{\"\"}}")
 		}
 	}


### PR DESCRIPTION
This PR allows end user to add source type as k8s Ingress (Now only OpenShift Route and K8s Service), which upstream already supported long time ago.

The use case can be.

**Given** User uses [AWS Load Balancer Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html)
**And** User uses External DNS Operator 
**When** User uses K8s Ingress to configure AWS **Application Load Balancer**
**Then** The external dns operator creates DNS record based on the Ingress Address (In this case it is ALB CNAME)

And example configuration can be

```
---
apiVersion: externaldns.olm.openshift.io/v1alpha1
kind: ExternalDNS
metadata:
  name: sample-aws 
spec:
  domains:
  - filterType: Include   
    matchType: Exact   
    name: ${domain}
  provider:
    type: AWS
  source:  
    type: Ingress
```

