### PR TITLE
NE-1323: Add default to AWS credentials field

### DIFF
--- a/api/v1beta1/externaldns_types.go
+++ b/api/v1beta1/externaldns_types.go
@@ -255,6 +255,7 @@ type ExternalDNSAWSProviderOptions struct {
 	// for more information.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default:={"name":""}
 	// +required
 	Credentials SecretReference `json:"credentials"`
 
@@ -491,7 +492,7 @@ const (
 )
 
 type ExternalDNSAWSAssumeRoleOptions struct {
-	// arn is an AWS role ARN that the ExternalDNS
+	// arn is an IAM role ARN that the ExternalDNS
 	// operator will assume when making DNS updates.
 	//
 	// +kubebuilder:validation:Required

--- a/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
@@ -576,11 +576,13 @@ spec:
                           updates.
                         properties:
                           arn:
-                            description: arn is an AWS role ARN that the ExternalDNS
+                            description: arn is an IAM role ARN that the ExternalDNS
                               operator will assume when making DNS updates.
                             type: string
                         type: object
                       credentials:
+                        default:
+                          name: ""
                         description: "Credentials is a reference to a secret containing
                           the following keys (with corresponding values): \n * aws_access_key_id
                           * aws_secret_access_key \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -578,11 +578,13 @@ spec:
                           updates.
                         properties:
                           arn:
-                            description: arn is an AWS role ARN that the ExternalDNS
+                            description: arn is an IAM role ARN that the ExternalDNS
                               operator will assume when making DNS updates.
                             type: string
                         type: object
                       credentials:
+                        default:
+                          name: ""
                         description: "Credentials is a reference to a secret containing
                           the following keys (with corresponding values): \n * aws_access_key_id
                           * aws_secret_access_key \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,25 +82,6 @@ spec:
     - '{{.Name}}.mydomain.net'
 ```
 
-**Note**: Due to a limitation of the `v1beta1` API requiring the `credentials` field, OpenShift users will be required
-to provide an empty (`""`) credentials field. The empty credentials will be ignored and the secret provided by
-OpenShift's Cloud Credentials Operator will be used:
-
-```yaml
-apiVersion: externaldns.olm.openshift.io/v1beta1
-kind: ExternalDNS
-metadata:
-  name: aws-example
-spec:
-  provider:
-    type: AWS
-    aws:
-      credentials:
-        name: "" # Empty Credentials
-      assumeRole:
-        arn: arn:aws:iam::123456789012:role/role-name # Replace with the desire Role ARN
-```
-
 ## GovCloud
 The operator makes the assumption that `ExternalDNS` instances which target GovCloud DNS also run on the GovCloud. This is needed to detect the AWS region.   
 As for the rest: the usage is exactly the same as for `AWS`.


### PR DESCRIPTION
By adding a default value to the `spec.provider.aws.credentials` field, it enables the configuration of `spec.provider.aws.assumeRole` for an OpenShift user that doesn't need to explicitly specify the `credentials` field. Otherwise, an OpenShift user must manually insert `""` as the credentials name to use the `assumeRole` field.

This improves user experience for the current v1beta1 release of ExternalDNS Operator while not introducing any breaking changes to the API. We are planning to properly fix this issue in a future ExternalDNS Operator API version by converting `Credentials` to an optional pointer.

Epic: https://issues.redhat.com/browse/NE-1299