### PR TITLE
[release-1.1] OWNERS: add Grant, remove CFE

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,7 @@ approvers:
   - rfredette
   - alebedev87
   - miheer
-  - lmzuccarelli
+  - gcs278
 reviewers:
   - knobunc
   - Miciah
@@ -15,5 +15,5 @@ reviewers:
   - rfredette
   - alebedev87
   - miheer
-  - lmzuccarelli
+  - gcs278
 component: DNS


### PR DESCRIPTION
This PR adds @gcs278 as owner and removes old owners from the CFE team.