### PR TITLE
OCPBUGS-26538: add infrastructure annotations

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -303,9 +303,15 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.2.0
     operatorframework.io/suggested-namespace: external-dns-operator
-    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/external-dns-operator

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -7,9 +7,15 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.2.0
     operatorframework.io/suggested-namespace: external-dns-operator
-    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
   name: external-dns-operator.v1.2.0


### PR DESCRIPTION
According to the Red Hat Operator's [Best practices](https://docs.engineering.redhat.com/display/CFC/Best_Practices) the infrastructure annotations are now required. The [old "infrastructure-features" annotation is deprecated](https://github.com/openshift/openshift-docs/pull/69579) hence it's removed. The old list of features is mapped to the new set.