### PR TITLE
OCPBUGS-28230: Add FallbackToLogsOnError to all pod containers

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -479,6 +479,7 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                terminationMessagePolicy: FallbackToLogsOnError
               - args:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
@@ -505,6 +506,7 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /var/run/secrets/serving-cert
                   name: metrics-cert

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -17,6 +17,7 @@ spec:
         - "--tls-cert-file=/var/run/secrets/serving-cert/tls.crt"
         - "--tls-private-key-file=/var/run/secrets/serving-cert/tls.key"
         - "--http2-disable"
+        terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 8443
           name: https

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,6 +39,7 @@ spec:
         - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
         - --leader-elect
         - --webhook-disable-http2
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         - name: OPERATOR_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This PR sets the termination message policy to [`FallbackToLogsOnError`](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/#customizing-the-termination-message) on all the operator containers.