### PR TITLE
OCPBUGS-32058: docs - add example of private dns zone for Azure provider

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -211,6 +211,34 @@ metadata:
           "apiVersion": "externaldns.olm.openshift.io/v1beta1",
           "kind": "ExternalDNS",
           "metadata": {
+            "name": "sample-azure-private"
+          },
+          "spec": {
+            "domains": [
+              {
+                "filterType": "Include",
+                "matchType": "Exact",
+                "name": "test-azure1.qe.azure.devcluster.openshift.com"
+              }
+            ],
+            "provider": {
+              "type": "Azure"
+            },
+            "source": {
+              "openshiftRouteOptions": {
+                "routerName": "default"
+              },
+              "type": "OpenShiftRoute"
+            },
+            "zones": [
+              "/subscriptions/53b4f551-f0fc-4bea-8cba-11111111111/resourceGroups/test-azure1-nxkxm-rg/providers/Microsoft.Network/privateDnsZones/test-azure1.qe.azure.devcluster.openshift.com"
+            ]
+          }
+        },
+        {
+          "apiVersion": "externaldns.olm.openshift.io/v1beta1",
+          "kind": "ExternalDNS",
+          "metadata": {
             "name": "sample-bluecat"
           },
           "spec": {

--- a/config/samples/azure/kustomization.yaml
+++ b/config/samples/azure/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - operator_v1beta1_externaldns_openshift.yaml
 - operator_v1alpha1_externaldns_openshift.yaml
+- operator_v1beta1_externaldns_openshift_private.yaml

--- a/config/samples/azure/operator_v1beta1_externaldns_openshift_private.yaml
+++ b/config/samples/azure/operator_v1beta1_externaldns_openshift_private.yaml
@@ -1,0 +1,20 @@
+apiVersion: externaldns.olm.openshift.io/v1beta1
+kind: ExternalDNS
+metadata:
+  name: sample-azure-private
+spec:
+  domains:
+  - filterType: Include
+    matchType: Exact
+    name: test-azure1.qe.azure.devcluster.openshift.com
+  provider:
+    type: Azure
+  source:
+    # Source Type is route resource of OpenShift
+    type: OpenShiftRoute
+    # In case you have multiple ingress controllers you must specify ingress controller name in the routerName
+    # so that the external dns will use the router canonical name correrponding to it to create a dns record.
+    openshiftRouteOptions:
+      routerName: default
+  zones:
+  - "/subscriptions/53b4f551-f0fc-4bea-8cba-11111111111/resourceGroups/test-azure1-nxkxm-rg/providers/Microsoft.Network/privateDnsZones/test-azure1.qe.azure.devcluster.openshift.com"


### PR DESCRIPTION
- Adds an example of the usage of the private dns zone for the Azure provider
- Addresses https://github.com/openshift/external-dns-operator/issues/197