### PR TITLE
OCPBUGS-37059: Support deployment on HCP clusters

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+# IAM policy
+
+Copied from [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns/blob/b84fc9384313ad459e1a0a11fccb09cc63460ba1/docs/tutorials/aws.md#iam-policy).

--- a/assets/iam_policy.json
+++ b/assets/iam_policy.json
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones",
+        "route53:ListResourceRecordSets",
+        "route53:ListTagsForResource"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/pkg/operator/controller/externaldns/deployment.go
+++ b/pkg/operator/controller/externaldns/deployment.go
@@ -201,8 +201,7 @@ func desiredExternalDNSDeployment(cfg *deploymentConfig) (*appsv1.Deployment, er
 	}
 
 	nodeSelectorLbl := map[string]string{
-		osLabel:             linuxOS,
-		masterNodeRoleLabel: "",
+		osLabel: linuxOS,
 	}
 
 	tolerations := []corev1.Toleration{

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -116,8 +116,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -242,8 +241,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -319,8 +317,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -428,8 +425,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -560,8 +556,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -662,8 +657,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -763,8 +757,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -841,8 +834,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -983,8 +975,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1089,8 +1080,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1167,8 +1157,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1245,8 +1234,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1345,8 +1333,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1422,8 +1409,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1525,8 +1511,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1600,8 +1585,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1670,8 +1654,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1742,8 +1725,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1851,8 +1833,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -1928,8 +1909,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2003,8 +1983,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2079,8 +2058,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2158,8 +2136,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2279,8 +2256,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2351,8 +2327,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2472,8 +2447,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2545,8 +2519,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2641,8 +2614,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2714,8 +2686,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2846,8 +2817,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -2947,8 +2917,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3019,8 +2988,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3114,8 +3082,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3186,8 +3153,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3284,8 +3250,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3354,8 +3319,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3423,8 +3387,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3522,8 +3485,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3594,8 +3556,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3664,8 +3625,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3735,8 +3695,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -3812,8 +3771,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: test.OperandName,
 						NodeSelector: map[string]string{
-							osLabel:             linuxOS,
-							masterNodeRoleLabel: "",
+							osLabel: linuxOS,
 						},
 						Tolerations: []corev1.Toleration{
 							{
@@ -4221,8 +4179,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -4351,8 +4308,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -4482,8 +4438,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -4612,8 +4567,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -4743,8 +4697,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -4874,8 +4827,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -4933,8 +4885,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -5072,8 +5023,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -5232,8 +5182,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -5363,8 +5312,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -5484,8 +5432,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -5614,8 +5561,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -5677,8 +5623,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{
@@ -5809,8 +5754,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName: test.OperandName,
 								NodeSelector: map[string]string{
-									osLabel:             linuxOS,
-									masterNodeRoleLabel: "",
+									osLabel: linuxOS,
 								},
 								Tolerations: []corev1.Toleration{
 									{
@@ -5932,8 +5876,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							ServiceAccountName: test.OperandName,
 							NodeSelector: map[string]string{
-								osLabel:             linuxOS,
-								masterNodeRoleLabel: "",
+								osLabel: linuxOS,
 							},
 							Tolerations: []corev1.Toleration{
 								{

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -141,6 +141,22 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name: "bound-sa-token",
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+													Audience:          "openshift",
+													ExpirationSeconds: pointer.Int64(3600),
+													Path:              "token",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						Containers: []corev1.Container{
 							{
@@ -174,6 +190,11 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									{
 										Name:      awsCredentialsVolumeName,
 										MountPath: awsCredentialsMountPath,
+										ReadOnly:  true,
+									},
+									{
+										Name:      "bound-sa-token",
+										MountPath: "/var/run/secrets/openshift/serviceaccount",
 										ReadOnly:  true,
 									},
 								},
@@ -432,6 +453,22 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name: "bound-sa-token",
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+													Audience:          "openshift",
+													ExpirationSeconds: pointer.Int64(3600),
+													Path:              "token",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						Containers: []corev1.Container{
 							{
@@ -470,6 +507,11 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									{
 										Name:      awsCredentialsVolumeName,
 										MountPath: awsCredentialsMountPath,
+										ReadOnly:  true,
+									},
+									{
+										Name:      "bound-sa-token",
+										MountPath: "/var/run/secrets/openshift/serviceaccount",
 										ReadOnly:  true,
 									},
 								},
@@ -2141,6 +2183,22 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name: "bound-sa-token",
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+													Audience:          "openshift",
+													ExpirationSeconds: pointer.Int64(3600),
+													Path:              "token",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						Containers: []corev1.Container{
 							{
@@ -2169,6 +2227,11 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									{
 										Name:      awsCredentialsVolumeName,
 										MountPath: awsCredentialsMountPath,
+										ReadOnly:  true,
+									},
+									{
+										Name:      "bound-sa-token",
+										MountPath: "/var/run/secrets/openshift/serviceaccount",
 										ReadOnly:  true,
 									},
 								},
@@ -2313,6 +2376,22 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name: "bound-sa-token",
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+													Audience:          "openshift",
+													ExpirationSeconds: pointer.Int64(3600),
+													Path:              "token",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						Containers: []corev1.Container{
 							{
@@ -2341,6 +2420,11 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									{
 										Name:      awsCredentialsVolumeName,
 										MountPath: awsCredentialsMountPath,
+										ReadOnly:  true,
+									},
+									{
+										Name:      "bound-sa-token",
+										MountPath: "/var/run/secrets/openshift/serviceaccount",
 										ReadOnly:  true,
 									},
 								},
@@ -4162,6 +4246,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -4188,6 +4288,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -4271,6 +4376,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											},
 										},
 									},
+									{
+										Name: "bound-sa-token",
+										VolumeSource: corev1.VolumeSource{
+											Projected: &corev1.ProjectedVolumeSource{
+												Sources: []corev1.VolumeProjection{
+													{
+														ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+															Audience:          "openshift",
+															ExpirationSeconds: pointer.Int64(3600),
+															Path:              "token",
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 								Containers: []corev1.Container{
 									{
@@ -4297,6 +4418,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											{
 												Name:      awsCredentialsVolumeName,
 												MountPath: awsCredentialsMountPath,
+												ReadOnly:  true,
+											},
+											{
+												Name:      "bound-sa-token",
+												MountPath: "/var/run/secrets/openshift/serviceaccount",
 												ReadOnly:  true,
 											},
 										},
@@ -4381,6 +4507,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -4409,6 +4551,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											MountPath: awsCredentialsMountPath,
 											ReadOnly:  true,
 										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
+											ReadOnly:  true,
+										},
 									},
 									SecurityContext: &corev1.SecurityContext{
 										Capabilities: &corev1.Capabilities{
@@ -4429,7 +4576,7 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 			},
 		},
 		{
-			name:   "Exist as expected with one Router Names added as flag",
+			name:   "Exist as expected with one router name added as flag",
 			extDNS: *testAWSExternalDNSHostnameAllow(operatorv1beta1.SourceTypeRoute, "default"),
 			existingObjects: []runtime.Object{
 				&appsv1.Deployment{
@@ -4490,6 +4637,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											},
 										},
 									},
+									{
+										Name: "bound-sa-token",
+										VolumeSource: corev1.VolumeSource{
+											Projected: &corev1.ProjectedVolumeSource{
+												Sources: []corev1.VolumeProjection{
+													{
+														ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+															Audience:          "openshift",
+															ExpirationSeconds: pointer.Int64(3600),
+															Path:              "token",
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 								Containers: []corev1.Container{
 									{
@@ -4515,6 +4678,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											{
 												Name:      awsCredentialsVolumeName,
 												MountPath: awsCredentialsMountPath,
+												ReadOnly:  true,
+											},
+											{
+												Name:      "bound-sa-token",
+												MountPath: "/var/run/secrets/openshift/serviceaccount",
 												ReadOnly:  true,
 											},
 										},
@@ -4600,6 +4768,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -4627,6 +4811,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -4769,6 +4958,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -4795,6 +5000,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -4903,6 +5113,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -4938,6 +5164,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      "aws-credentials",
 											MountPath: "/etc/kubernetes",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -5026,6 +5257,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -5053,6 +5300,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -5136,6 +5388,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											},
 										},
 									},
+									{
+										Name: "bound-sa-token",
+										VolumeSource: corev1.VolumeSource{
+											Projected: &corev1.ProjectedVolumeSource{
+												Sources: []corev1.VolumeProjection{
+													{
+														ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+															Audience:          "openshift",
+															ExpirationSeconds: pointer.Int64(3600),
+															Path:              "token",
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 								Containers: []corev1.Container{
 									{
@@ -5163,6 +5431,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 											{
 												Name:      awsCredentialsVolumeName,
 												MountPath: awsCredentialsMountPath,
+												ReadOnly:  true,
+											},
+											{
+												Name:      "bound-sa-token",
+												MountPath: "/var/run/secrets/openshift/serviceaccount",
 												ReadOnly:  true,
 											},
 										},
@@ -5236,6 +5509,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -5263,6 +5552,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -5408,6 +5702,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -5435,6 +5745,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      awsCredentialsVolumeName,
 											MountPath: awsCredentialsMountPath,
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},
@@ -5656,6 +5971,22 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "bound-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          "openshift",
+														ExpirationSeconds: pointer.Int64(3600),
+														Path:              "token",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -5688,6 +6019,11 @@ func TestEnsureExternalDNSDeployment(t *testing.T) {
 										{
 											Name:      "unsolicited-vm",
 											MountPath: "somepath",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "bound-sa-token",
+											MountPath: "/var/run/secrets/openshift/serviceaccount",
 											ReadOnly:  true,
 										},
 									},


### PR DESCRIPTION
- [Add bound service account token to operand deployment](https://github.com/openshift/external-dns-operator/commit/140a78bb49947d9100d1e8976767ee569495f7a4)
- [Update docs with STS chapter](https://github.com/openshift/external-dns-operator/commit/daaf9f67f83c9fc6833cad7878fe72b93cbd92f0)
- [Relax node placement for operand](https://github.com/openshift/external-dns-operator/commit/a5dfddb958ef7624b7eba8e20daedfab57ecfa7e)