### PR TITLE
OCPBUGS-36797: Revisit links to upstream docs in API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ bundle-image-push:
 
 .PHONY: catalog
 catalog: opm
+	# TODO: make opm use the bundle image built locally
 	$(OPM) render $(BUNDLE_IMG) -o yaml > $(PACKAGE_DIR)/bundle.yaml
 	$(OPM) validate $(CATALOG_DIR)
 

--- a/api/v1beta1/externaldns_types.go
+++ b/api/v1beta1/externaldns_types.go
@@ -250,10 +250,6 @@ type ExternalDNSAWSProviderOptions struct {
 	// * aws_access_key_id
 	// * aws_secret_access_key
 	//
-	// See
-	// https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md
-	// for more information.
-	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:={"name":""}
 	// +required
@@ -304,7 +300,7 @@ type ExternalDNSAzureProviderOptions struct {
 	// }
 	//
 	// See
-	// https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md
+	// https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/azure.md#configuration-file
 	// for more information on the necessary configuration key/values and how to obtain them.
 	//
 	// +kubebuilder:validation:Required
@@ -329,7 +325,7 @@ type ExternalDNSBlueCatProviderOptions struct {
 	// }
 	//
 	// See
-	// https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/bluecat.md
+	// https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/bluecat.md#using-json-configuration-file
 	// for more information on the necessary configuration values and how to obtain them.
 	//
 	// +kubebuilder:validation:Required
@@ -343,10 +339,6 @@ type ExternalDNSInfobloxProviderOptions struct {
 	//
 	// * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
 	// * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-	//
-	// See
-	// https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/infoblox.md
-	// for more information and configuration options.
 	//
 	// +kubebuilder:validation:Required
 	// +required

--- a/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
@@ -587,8 +587,7 @@ spec:
                           name: ""
                         description: "Credentials is a reference to a secret containing
                           the following keys (with corresponding values): \n * aws_access_key_id
-                          * aws_secret_access_key \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md
-                          for more information."
+                          * aws_secret_access_key"
                         properties:
                           name:
                             description: Name is the name of the secret.
@@ -610,7 +609,7 @@ spec:
                           `azure.json` similar to the following: \n {   \"tenantId\":
                           \"123\",   \"subscriptionId\": \"456\",   \"resourceGroup\":
                           \"MyDnsResourceGroup\",   \"aadClientId\": \"789\",   \"aadClientSecret\":
-                          \"123\" } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md
+                          \"123\" } \n See https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/azure.md#configuration-file
                           for more information on the necessary configuration key/values
                           and how to obtain them."
                         properties:
@@ -635,7 +634,7 @@ spec:
                           \"https://bluecatgw.example.com\",   \"gatewayUsername\":
                           \"user\",   \"gatewayPassword\": \"pass\",   \"dnsConfiguration\":
                           \"Example\",   \"dnsView\": \"Internal\",   \"rootZone\":
-                          \"example.com\",   \"skipTLSVerify\": false } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/bluecat.md
+                          \"example.com\",   \"skipTLSVerify\": false } \n See https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/bluecat.md#using-json-configuration-file
                           for more information on the necessary configuration values
                           and how to obtain them."
                         properties:
@@ -680,9 +679,7 @@ spec:
                       credentials:
                         description: "Credentials is a reference to a secret containing
                           the following keys (with proper corresponding values): \n
-                          * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-                          \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/infoblox.md
-                          for more information and configuration options."
+                          * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
                         properties:
                           name:
                             description: Name is the name of the secret.

--- a/catalog/external-dns-operator/bundle.yaml
+++ b/catalog/external-dns-operator/bundle.yaml
@@ -321,9 +321,15 @@ properties:
       certified: "false"
       containerImage: quay.io/openshift/origin-external-dns-operator:latest
       createdAt: 2021/09/28
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
       olm.skipRange: <1.2.0
       operatorframework.io/suggested-namespace: external-dns-operator
-      operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
       operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
       repository: https://github.com/openshift/external-dns-operator

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -589,8 +589,7 @@ spec:
                           name: ""
                         description: "Credentials is a reference to a secret containing
                           the following keys (with corresponding values): \n * aws_access_key_id
-                          * aws_secret_access_key \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md
-                          for more information."
+                          * aws_secret_access_key"
                         properties:
                           name:
                             description: Name is the name of the secret.
@@ -612,7 +611,7 @@ spec:
                           `azure.json` similar to the following: \n {   \"tenantId\":
                           \"123\",   \"subscriptionId\": \"456\",   \"resourceGroup\":
                           \"MyDnsResourceGroup\",   \"aadClientId\": \"789\",   \"aadClientSecret\":
-                          \"123\" } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md
+                          \"123\" } \n See https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/azure.md#configuration-file
                           for more information on the necessary configuration key/values
                           and how to obtain them."
                         properties:
@@ -637,7 +636,7 @@ spec:
                           \"https://bluecatgw.example.com\",   \"gatewayUsername\":
                           \"user\",   \"gatewayPassword\": \"pass\",   \"dnsConfiguration\":
                           \"Example\",   \"dnsView\": \"Internal\",   \"rootZone\":
-                          \"example.com\",   \"skipTLSVerify\": false } \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/bluecat.md
+                          \"example.com\",   \"skipTLSVerify\": false } \n See https://github.com/kubernetes-sigs/external-dns/blob/226dbb931f7a2019810b3703aec096c4ea4f40ea/docs/tutorials/bluecat.md#using-json-configuration-file
                           for more information on the necessary configuration values
                           and how to obtain them."
                         properties:
@@ -682,9 +681,7 @@ spec:
                       credentials:
                         description: "Credentials is a reference to a secret containing
                           the following keys (with proper corresponding values): \n
-                          * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-                          \n See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/infoblox.md
-                          for more information and configuration options."
+                          * EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME * EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
                         properties:
                           name:
                             description: Name is the name of the secret.


### PR DESCRIPTION
- Removed links that don't add value and may mislead users (AWS, Infoblox: secret format).
- Pinned remaining links to specific commits and anchored them to relevant chapters.