### PR TITLE
OCPBUGS-41683: Use RHEL9 as baseimage and build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make build-operator
 
 # Use minimal base image to package the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/external-dns-operator .
 


### PR DESCRIPTION
Change RHEL version to RHEL9 for building and base images. [The operand image with RHEL9](https://github.com/openshift/external-dns/pull/61) has already been added as a part of https://github.com/openshift/external-dns-operator/pull/225.