### PR TITLE
NE-1802: Update the operand image to 0.14.2

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -449,7 +449,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_EXTERNAL_DNS
-                  value: quay.io/external-dns-operator/external-dns@sha256:6fa3afebbc99926163d4c827a638473e106e6589e9f3d3d3accd3e426693f04f
+                  value: quay.io/external-dns-operator/external-dns@sha256:51e2acc81c804468932581379d674273fd2e62798be4e81c5c735bf0161590dd
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: quay.io/openshift/origin-external-dns-operator:latest
                 name: external-dns-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,8 +46,9 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_EXTERNAL_DNS
-          # openshift/external-dns commit: 0e095a3db5ae9518a1744dd85d3f7ed2e359768d
-          value: quay.io/external-dns-operator/external-dns@sha256:6fa3afebbc99926163d4c827a638473e106e6589e9f3d3d3accd3e426693f04f
+          # openshift/external-dns commit: 441588e482514db7722f5c793cf70348b68d952d
+          # manifest link: https://quay.io/repository/external-dns-operator/external-dns/manifest/sha256:51e2acc81c804468932581379d674273fd2e62798be4e81c5c735bf0161590dd
+          value: quay.io/external-dns-operator/external-dns@sha256:51e2acc81c804468932581379d674273fd2e62798be4e81c5c735bf0161590dd
         - name: TRUSTED_CA_CONFIGMAP_NAME
         securityContext:
           capabilities:


### PR DESCRIPTION
This PR updates the operand image to include the latest changes from the upstream's 0.14.2 version, as introduced in [the rebase PR](https://github.com/openshift/external-dns/pull/58).

External-dns repository from quay.io: [link](https://quay.io/repository/external-dns-operator/external-dns?tab=tags) (`latest` tag).