### PR TITLE
OCPBUGS-42220: Infoblox - use 2.12.2 WAPI version

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -139,7 +139,7 @@ metadata:
                 },
                 "gridHost": "100.100.100.100",
                 "wapiPort": 443,
-                "wapiVersion": "2.3.1"
+                "wapiVersion": "2.12.2"
               },
               "type": "Infoblox"
             },
@@ -286,7 +286,7 @@ metadata:
                 },
                 "gridHost": "100.100.100.100",
                 "wapiPort": 443,
-                "wapiVersion": "2.3.1"
+                "wapiVersion": "2.12.2"
               },
               "type": "Infoblox"
             },

--- a/config/samples/infoblox/operator_v1alpha1_infoblox_detailed.yaml
+++ b/config/samples/infoblox/operator_v1alpha1_infoblox_detailed.yaml
@@ -11,7 +11,7 @@ spec:
         name: infoblox-credentials
       gridHost: "100.100.100.100"
       wapiPort: 443
-      wapiVersion: "2.3.1"
+      wapiVersion: "2.12.2"
   # filter DNS zones
   domains:
   - filterType: Include

--- a/config/samples/infoblox/operator_v1alpha1_infoblox_openshift.yaml
+++ b/config/samples/infoblox/operator_v1alpha1_infoblox_openshift.yaml
@@ -14,7 +14,7 @@ spec:
         name: infoblox-credentials
       gridHost: "100.100.100.100"
       wapiPort: 443
-      wapiVersion: "2.3.1"
+      wapiVersion: "2.12.2"
   source:
     # Source Type is route resource of OpenShift
     type: OpenShiftRoute

--- a/config/samples/infoblox/operator_v1beta1_infoblox_openshift.yaml
+++ b/config/samples/infoblox/operator_v1beta1_infoblox_openshift.yaml
@@ -14,7 +14,7 @@ spec:
         name: infoblox-credentials
       gridHost: "100.100.100.100"
       wapiPort: 443
-      wapiVersion: "2.3.1"
+      wapiVersion: "2.12.2"
   source:
     # Source Type is route resource of OpenShift
     type: OpenShiftRoute

--- a/docs/infoblox-openshift.md
+++ b/docs/infoblox-openshift.md
@@ -50,7 +50,7 @@ openshift-console          downloads           downloads-openshift-console.apps.
             name: infoblox-credentials
           gridHost: ${INFOBLOX_GRID_PUBLIC_IP}
           wapiPort: 443
-          wapiVersion: "2.3.1"
+          wapiVersion: "2.12.2"
       domains:
       - filterType: Include
         matchType: Exact

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -1440,7 +1440,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									"--fqdn-template={{.Name}}.test.com",
 									"--infoblox-wapi-port=443",
 									"--infoblox-grid-host=gridhost.example.com",
-									"--infoblox-wapi-version=2.3.1",
+									"--infoblox-wapi-version=2.12.2",
 									"--txt-prefix=external-dns-",
 								},
 								Env: []corev1.EnvVar{
@@ -3179,7 +3179,7 @@ func TestDesiredExternalDNSDeployment(t *testing.T) {
 									`--fqdn-template={{""}}`,
 									"--infoblox-wapi-port=443",
 									"--infoblox-grid-host=gridhost.example.com",
-									"--infoblox-wapi-version=2.3.1",
+									"--infoblox-wapi-version=2.12.2",
 									"--txt-prefix=external-dns-",
 								},
 								Env: []corev1.EnvVar{
@@ -6727,7 +6727,7 @@ func testInfobloxExternalDNS(source operatorv1beta1.ExternalDNSSourceType) *oper
 	extdns.Spec.Provider.Infoblox = &operatorv1beta1.ExternalDNSInfobloxProviderOptions{
 		GridHost:    "gridhost.example.com",
 		WAPIPort:    443,
-		WAPIVersion: "2.3.1",
+		WAPIVersion: "2.12.2",
 	}
 	return extdns
 }

--- a/test/e2e/infoblox.go
+++ b/test/e2e/infoblox.go
@@ -35,15 +35,18 @@ const (
 	infobloxGridMasterHostnameEnvVar = "INFOBLOX_GRID_MASTER_HOSTNAME"
 	trustedCAConfigMapEnvVar         = "TRUSTED_CA_CONFIGMAP_NAME"
 	defaultWAPIPort                  = "443"
-	defaultWAPIVersion               = "2.3.1"
-	defaultTLSVerify                 = "false"
-	defaultHTTPRequestTimeout        = 20
-	defaultHTTPConnPool              = 10
-	defaultHostFilename              = "host"
-	defaultUsernameFilename          = "username"
-	defaultPasswordFilename          = "password"
-	defaultMasterHostnameFilename    = "masterhostname"
-	operatorContainerName            = "operator"
+	// https://community.infoblox.com/cixhp49439/attachments/cixhp49439/IPAM/6153/2/NIOS_8.6.2_ReleaseNotesREVC.pdf
+	// Chapter: "Changes to Infoblox API and Restful API (WAPI)"
+	// "2.12.2" version is recommended for NIOS 8.6.2 (our Infoblox test instance is currently 8.6.4).
+	defaultWAPIVersion            = "2.12.2"
+	defaultTLSVerify              = "false"
+	defaultHTTPRequestTimeout     = 20
+	defaultHTTPConnPool           = 10
+	defaultHostFilename           = "host"
+	defaultUsernameFilename       = "username"
+	defaultPasswordFilename       = "password"
+	defaultMasterHostnameFilename = "masterhostname"
+	operatorContainerName         = "operator"
 )
 
 type infobloxTestHelper struct {


### PR DESCRIPTION
This PR aims at updating the nominal version of Infoblox's WAPI we test our operator against. The test Infoblox instance we use is recommended to be used with `2.12.2` WAPI version ([Infoblox ref](https://community.infoblox.com/cixhp49439/attachments/cixhp49439/IPAM/6153/2/NIOS_8.6.2_ReleaseNotesREVC.pdf)).