### PR TITLE
NE-1777: Add new OLM channel for 1.3 release

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -5,7 +5,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=external-dns-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.2,stable-v1
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.3,stable-v1
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
 
 # Copy files to locations specified by labels.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 1.2.0
+BUNDLE_VERSION ?= 1.3.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -310,13 +310,13 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: <1.2.0
+    olm.skipRange: <1.3.0
     operatorframework.io/suggested-namespace: external-dns-operator
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
-  name: external-dns-operator.v1.2.0
+  name: external-dns-operator.v1.3.0
   namespace: external-dns-operator
 spec:
   apiservicedefinitions: {}
@@ -597,7 +597,7 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: Red Hat, Inc.
-  version: 1.2.0
+  version: 1.3.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -312,6 +312,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.3.0
     operatorframework.io/suggested-namespace: external-dns-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/external-dns-operator

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: "manifests/"
   operators.operatorframework.io.bundle.metadata.v1: "metadata/"
   operators.operatorframework.io.bundle.package.v1: "external-dns-operator"
-  operators.operatorframework.io.bundle.channels.v1: "stable-v1.2,stable-v1"
+  operators.operatorframework.io.bundle.channels.v1: "stable-v1.3,stable-v1"
   operators.operatorframework.io.bundle.channel.default.v1: "stable-v1"
   # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
   com.redhat.delivery.backport: false

--- a/catalog/external-dns-operator/bundle.yaml
+++ b/catalog/external-dns-operator/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: quay.io/external-dns-operator/external-dns-operator-bundle:latest
-name: external-dns-operator.v1.2.0
+name: external-dns-operator.v1.3.0
 package: external-dns-operator
 properties:
 - type: olm.gvk
@@ -16,7 +16,7 @@ properties:
 - type: olm.package
   value:
     packageName: external-dns-operator
-    version: 1.2.0
+    version: 1.3.0
 - type: olm.csv.metadata
   value:
     annotations:
@@ -328,7 +328,7 @@ properties:
       features.operators.openshift.io/token-auth-aws: "false"
       features.operators.openshift.io/token-auth-azure: "false"
       features.operators.openshift.io/token-auth-gcp: "false"
-      olm.skipRange: <1.2.0
+      olm.skipRange: <1.3.0
       operatorframework.io/suggested-namespace: external-dns-operator
       operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/catalog/external-dns-operator/bundle.yaml
+++ b/catalog/external-dns-operator/bundle.yaml
@@ -330,6 +330,8 @@ properties:
       features.operators.openshift.io/token-auth-gcp: "false"
       olm.skipRange: <1.3.0
       operatorframework.io/suggested-namespace: external-dns-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
       operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
       repository: https://github.com/openshift/external-dns-operator

--- a/catalog/external-dns-operator/channel.yaml
+++ b/catalog/external-dns-operator/channel.yaml
@@ -3,10 +3,10 @@ schema: olm.channel
 name: stable-v1
 package: external-dns-operator
 entries:
-  - name: external-dns-operator.v1.2.0
+  - name: external-dns-operator.v1.3.0
 ---
 schema: olm.channel
-name: stable-v1.2
+name: stable-v1.3
 package: external-dns-operator
 entries:
-  - name: external-dns-operator.v1.2.0
+  - name: external-dns-operator.v1.3.0

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -14,11 +14,11 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: <1.2.0
+    olm.skipRange: <1.3.0
     operatorframework.io/suggested-namespace: external-dns-operator
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
-  name: external-dns-operator.v1.2.0
+  name: external-dns-operator.v1.3.0
   namespace: external-dns-operator
 spec:
   apiservicedefinitions: {}
@@ -72,4 +72,4 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: Red Hat, Inc.
-  version: 1.2.0
+  version: 1.3.0

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -16,6 +16,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.3.0
     operatorframework.io/suggested-namespace: external-dns-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     repository: https://github.com/openshift/external-dns-operator
     support: Red Hat, Inc.
   name: external-dns-operator.v1.3.0

--- a/docs/openshift.md
+++ b/docs/openshift.md
@@ -14,6 +14,9 @@ $ ./hack/add-serving-cert.sh --namespace external-dns-operator --service webhook
 ## Release-branch mapping
 | OCP version | ExternalDNS Operator branch |
 | :---------: | :-------------------------: |
+| 4.17        | release-1.3                 |
+| 4.16        | release-1.2                 |
+| 4.15        | release-1.2                 |
 | 4.14        | release-1.2                 |
 | 4.13        | release-1.1                 |
 | 4.12        | release-1.1                 |


### PR DESCRIPTION
This PR:
- updates `config/manifests`  to use the new version (`1.3.0`) for CSV
- regenerates the bundle using `make bundle` command
- updates `catalog` with new bundle version and new minor version channel using `make catalog` command
- updates the bundle metadata in `Dockerfile.bundle` and `bundle/metadata/annotations.yaml` with the new minor version channel
- updates `docs/openshift.md` with the new (and missing) branch mappings

Also:
- New commit added to handle the flaky patching of operator subscription with Infoblox CA.
- Another new commit added to fix the CPaaS CVP warning about missing valid subscription annotation.