### PR TITLE
[WIP] catalog: build and push bundle image on the fly

### DIFF
--- a/catalog/external-dns-operator/bundle.yaml
+++ b/catalog/external-dns-operator/bundle.yaml
@@ -1,5 +1,5 @@
 ---
-image: quay.io/external-dns-operator/external-dns-operator-bundle:latest
+image: quay.io/external-dns-operator/external-dns-operator-bundle:3be5a66
 name: external-dns-operator.v1.2.0
 package: external-dns-operator
 properties:
@@ -321,9 +321,15 @@ properties:
       certified: "false"
       containerImage: quay.io/openshift/origin-external-dns-operator:latest
       createdAt: 2021/09/28
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
       olm.skipRange: <1.2.0
       operatorframework.io/suggested-namespace: external-dns-operator
-      operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
       operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
       repository: https://github.com/openshift/external-dns-operator
@@ -373,7 +379,7 @@ properties:
     provider:
       name: Red Hat, Inc.
 relatedImages:
-- image: quay.io/external-dns-operator/external-dns-operator-bundle:latest
+- image: quay.io/external-dns-operator/external-dns-operator-bundle:3be5a66
   name: ""
 - image: quay.io/openshift/origin-external-dns-operator:latest
   name: ""


### PR DESCRIPTION
The FBC needs the bundle image it can render from. This commit adds the build/push of the bundle image to "catalog" target. To avoid conflicts in CI, different PRs require unique versions of the bundle image. The current commit enables separation of bundle images across PRs.