### PR TITLE
NE-2053: Add dedicated Containerfile for Konflux builds

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -1,0 +1,29 @@
+# Detect the drift from the upstream Dockerfile
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS drift
+WORKDIR /app
+COPY drift-cache/Dockerfile Dockerfile.cached
+COPY Dockerfile .
+# If the command below fails it means that the upstream Dockerfile changed.
+# You have to update the Konflux Containerfile accordingly.
+# drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
+RUN [ "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)" ]
+
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
+# dummy copy to trigger the drift detection
+COPY --from=drift /app/Dockerfile.cached .
+COPY . /workspace
+WORKDIR /workspace
+RUN git config --global --add safe.directory /workspace
+# Build
+RUN make build-operator
+
+FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+LABEL maintainer="Red Hat, Inc."
+LABEL com.redhat.component="external-dns-operator-container"
+LABEL name="external-dns-operator"
+LABEL version="${CI_VERSION}"
+WORKDIR /
+COPY --from=builder /workspace/bin/external-dns-operator /
+USER 65532:65532
+ENTRYPOINT ["/external-dns-operator"]

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,0 +1,16 @@
+# Build the manager binary
+FROM golang:1.22 as builder
+
+WORKDIR /opt/app-root/src
+COPY . .
+
+# Build
+RUN make build-operator
+
+# Use minimal base image to package the manager binary
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+WORKDIR /
+COPY --from=builder /opt/app-root/src/bin/external-dns-operator .
+
+ENTRYPOINT ["/external-dns-operator"]
+


### PR DESCRIPTION
This PR adds a dedicated Containerfile that can be referenced by the Konflux operator component. It automatically detects drift from the `Dockerfile`, thereby enforcing synchronization between the version used in CI presubmits and Konflux.

The base image used matches the minor version that was in use in CPaaS at the time the migration to Konflux began. This ensures continuity with previous releases.

The builder image, on the other hand, has been set to `registry.access.redhat.com/ubi8/go-toolset` to avoid relying on `registry-proxy.engineering.redhat.com` (used in CPaaS) and to stay consistent with the builder image samples recommended by the Konflux migration team.