### PR TITLE
OCPBUGS-57330: e2e_sharedvpc: Skip deletion of ExternalDNS if test failed

### DIFF
--- a/test/e2e_sharedvpc/shared_vpc_test.go
+++ b/test/e2e_sharedvpc/shared_vpc_test.go
@@ -106,7 +106,11 @@ func TestExternalDNSAssumeRole(t *testing.T) {
 		t.Fatalf("Failed to create external DNS %q: %v", testExtDNSName, err)
 	}
 	defer func() {
-		_ = common.KubeClient.Delete(context.TODO(), extDNS)
+		if !t.Failed() {
+			_ = common.KubeClient.Delete(context.TODO(), extDNS)
+		} else {
+			t.Logf("Skipping deletion of ExternalDNS %q to gather logs", testExtDNSName)
+		}
 	}()
 
 	// Create a service of type LoadBalancer with the annotation targeted by the ExternalDNS resource.


### PR DESCRIPTION
By skipping the deletion of ExternalDNS instance we allow must-gather to collect the state of the custom resource and operand deployment. Follow-up to https://github.com/openshift/release/pull/66025#issuecomment-2970592107.