### PR TITLE
OCPBUGS-57339: Use floating tag for operand image

### DIFF
--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -479,7 +479,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_EXTERNAL_DNS
-                  value: quay.io/external-dns-operator/external-dns@sha256:42c9f6d6b01d5e45b7d5064d2d6dea1f7b51346198d80e7f7f9821bd7fd072cf
+                  value: quay.io/external-dns-operator/external-dns:latest
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: quay.io/openshift/origin-external-dns-operator:latest
                 name: external-dns-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,9 +46,9 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_EXTERNAL_DNS
-          # openshift/external-dns commit: 8da2509b922d50ef7b1b8ea2297758888f32448d
-          # manifest link: https://quay.io/repository/external-dns-operator/external-dns/manifest/sha256:42c9f6d6b01d5e45b7d5064d2d6dea1f7b51346198d80e7f7f9821bd7fd072cf
-          value: quay.io/external-dns-operator/external-dns@sha256:42c9f6d6b01d5e45b7d5064d2d6dea1f7b51346198d80e7f7f9821bd7fd072cf
+            # Use "latest" floating tag to avoid problems with the prunning of older mirorred images.
+            # Ref: https://issues.redhat.com/browse/OCPBUGS-57339.
+          value: quay.io/external-dns-operator/external-dns:latest
         - name: TRUSTED_CA_CONFIGMAP_NAME
         securityContext:
           capabilities:


### PR DESCRIPTION
This commit changes the strategy used to reference the operand image in the operator's deployment manifest. The `latest` floating tag is now used to avoid issues with older mirrored images being removed.

Since these manifests are used only in CI presubmits, there is no risk of breaking future releases, which will have pinned versions (SHA256 digests) for all images.

Similar PR in ALBO: https://github.com/openshift/aws-load-balancer-operator/pull/161.