### PR TITLE
[DO NOT MERGE] NE-2053: Update base image to UBI

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -25,7 +25,7 @@ RUN git config --global --add safe.directory /workspace
 # Build
 RUN make build-operator
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4-943.1729773477
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1751287003
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-operator-container"
 LABEL name="external-dns-operator"


### PR DESCRIPTION
The RHEL ELS image had limited use and was previously chosen because UBI was not FIPS-ready. Now, UBI is the recommended base image for all customer-facing container images. It is also the most popular base image in Konflux.