### PR TITLE
NE-2054: Add Containerfile for Konflux bundle image

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -1,11 +1,11 @@
-# Detect the drift from the upstream Dockerfile
+# Detect the drift from Dockerfile.
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
 WORKDIR /app
 COPY drift-cache/Dockerfile Dockerfile.cached
 COPY Dockerfile .
 # If the command below fails it means that the Dockerfile from this repository changed.
 # You have to update the Konflux Containerfile accordingly.
-# drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
+# drift-cache/Dockerfile can be updated with latest contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
 

--- a/Containerfile.external-dns-operator-bundle
+++ b/Containerfile.external-dns-operator-bundle
@@ -1,0 +1,40 @@
+# Detect the drift from Dockerfile.bundle.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
+WORKDIR /app
+COPY drift-cache/Dockerfile.bundle Dockerfile.cached
+COPY Dockerfile.bundle .
+# If the command below fails it means that Dockerfile.bundle from this repository changed.
+# You have to update the Konflux Containerfile accordingly.
+# drift-cache/Dockerfile.bundle can be updated with latest contents once the Konflux version is aligned.
+RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile.bundle | cut -d' ' -f1)"
+
+# Customize bundle contents.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS update
+RUN microdnf install -y skopeo jq python3 python3-pip
+RUN pip3 install --upgrade pip && pip3 install ruamel.yaml==0.17.9
+
+COPY bundle-hack .
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+
+RUN ./update_bundle.sh
+
+# Based on Dockerfile.bundle file.
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=external-dns-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.3,stable-v1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
+
+# Dummy copy to trigger drift detection.
+COPY --from=drift /app/Dockerfile.cached .
+# Dummy copy to trigger bundle update.
+COPY --from=update /update_bundle.sh .
+
+# Copy customized files to locations specified by labels.
+COPY --from=update /manifests /manifests/
+COPY --from=update /metadata /metadata/

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Bundle updated!"
+
+exit 0

--- a/drift-cache/Dockerfile.bundle
+++ b/drift-cache/Dockerfile.bundle
@@ -1,0 +1,13 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=external-dns-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1.3,stable-v1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/


### PR DESCRIPTION
Adds a new Containerfile to build the operator bundle image using Konflux. This is a three-stage image: the first stage detects a drift from `Dockerfile.bundle`, the second stage customizes the bundle contents on the fly (currently a no-op placeholder), and the third stage reuses the existing `Dockerfile.bundle`.