### PR TITLE
NE-2073: Configure Renovate updates of images and tekton pipelines

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["dockerfile", "tekton"],
+  "packageRules": [
+    {
+      "description": "Disable all Dockerfile updates by default. Only specific files will get targeted.",
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
+    {
+      "description": "Enable Docker image updates for Red Hat UBI images on major version 9",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.external-dns-operator"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/ubi",
+        "registry.access.redhat.com/ubi9/ubi-minimal"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^9(\\.|$)/",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
+    },
+    {
+      "description": "Keep Go toolset on minor version 1.22",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.external-dns-operator"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/go-toolset"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^1\\.22(\\.|$)/",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
+    }
+  ],
+  "tekton": {
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/"
+    ],
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          "/^quay.io/redhat-appstudio-tekton-catalog//",
+          "/^quay.io/konflux-ci/tekton-catalog//",
+          "/^quay.io/konflux-ci/konflux-vanguard//"
+        ],
+        "enabled": true,
+        "groupName": "Konflux references",
+        "branchPrefix": "konflux/references/",
+        "additionalBranchPrefix": "",
+        "group": {
+          "branchTopic": "{{{baseBranch}}}",
+          "commitMessageTopic": "{{{groupName}}}"
+        },
+        "commitMessageTopic": "Konflux references",
+        "prBodyColumns": [
+          "Package",
+          "Change",
+          "Notes"
+        ],
+        "prBodyDefinitions": {
+          "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}"
+        },
+        "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch"
+      }
+    ],
+    "schedule": [
+      "after 5am on tuesday"
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "pipeline-migration-tool migrate -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+      ],
+      "executionMode": "branch",
+      "dataFileTemplate": "[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}{{#unless @last}},{{\/unless}}{{\/each}}]"
+    }
+  }
+}


### PR DESCRIPTION
Add Renovate/MintMaker configuration which:

- Configures base and builder images updates restricted to be only within the major version 9.
- go-toolset version updates restricted to be within the minor version 1.22.
- Disable all gomod bump PRs to avoid the unnecessary noise. The automated updates were found to be failing the build too often to be considered useful.
- Konflux dependencies updates (tekton pipelines) configuration. This was based on the default MintMaker configuration [konflux-ci/mintmaker/config/renovate/renovate.json](https://github.com/konflux-ci/mintmaker/blob/5f632ab7a9aabdff16092cc05127995c37c81d94/config/renovate/renovate.json#L70-L116):
One difference is that updates to quay.io/konflux-ci/konflux-vanguard were also added to be grouped into a single PR. The source config only groups together the updates to: quay.io/konflux-ci/tekton-catalog and quay.io/redhat-appstudio-tekton-catalog.

Renovate docs for the relevant fields and configurations:

- [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)
- [vulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)
- [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)
- [Red Hat Versioning](https://docs.renovatebot.com/modules/versioning/redhat/)
- [Konflux-CI docs: Dependency Management/Default configuration](https://konflux.pages.redhat.com/docs/users/mintmaker/default-config.html#tekton-updates)
- [github.com/konflux-ci/build-definitions: Task Migration](https://github.com/konflux-ci/build-definitions/?tab=readme-ov-file#task-migration)

[Dry run](https://docs.renovatebot.com/self-hosted-configuration/#dryrun) testing done using the `renovate` CLI npm package:
```bash
LOG_LEVEL=debug npx renovate@41.49.1 --token $GITHUB_TOKEN --dry-run=full grzpiotrowski/external-dns-operator
```