### PR TITLE
NE-2076: Update catalog to version 1.3.1

### DIFF
--- a/catalog/external-dns-operator/bundle.yaml
+++ b/catalog/external-dns-operator/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: quay.io/external-dns-operator/external-dns-operator-bundle:latest
-name: external-dns-operator.v1.3.0
+name: external-dns-operator.v1.3.1
 package: external-dns-operator
 properties:
 - type: olm.gvk
@@ -16,7 +16,7 @@ properties:
 - type: olm.package
   value:
     packageName: external-dns-operator
-    version: 1.3.0
+    version: 1.3.1
 - type: olm.csv.metadata
   value:
     annotations:
@@ -157,7 +157,7 @@ properties:
                   },
                   "gridHost": "100.100.100.100",
                   "wapiPort": 443,
-                  "wapiVersion": "2.3.1"
+                  "wapiVersion": "2.12.2"
                 },
                 "type": "Infoblox"
               },
@@ -222,6 +222,34 @@ properties:
               },
               "zones": [
                 "/subscriptions/53b4f551-f0fc-4bea-8cba-11111111111/resourceGroups/test-azure1-nxkxm-rg/providers/Microsoft.Network/dnszones/test-azure1.qe.azure.devcluster.openshift.com"
+              ]
+            }
+          },
+          {
+            "apiVersion": "externaldns.olm.openshift.io/v1beta1",
+            "kind": "ExternalDNS",
+            "metadata": {
+              "name": "sample-azure-private"
+            },
+            "spec": {
+              "domains": [
+                {
+                  "filterType": "Include",
+                  "matchType": "Exact",
+                  "name": "test-azure1.qe.azure.devcluster.openshift.com"
+                }
+              ],
+              "provider": {
+                "type": "Azure"
+              },
+              "source": {
+                "openshiftRouteOptions": {
+                  "routerName": "default"
+                },
+                "type": "OpenShiftRoute"
+              },
+              "zones": [
+                "/subscriptions/53b4f551-f0fc-4bea-8cba-11111111111/resourceGroups/test-azure1-nxkxm-rg/providers/Microsoft.Network/privateDnsZones/test-azure1.qe.azure.devcluster.openshift.com"
               ]
             }
           },
@@ -304,7 +332,7 @@ properties:
                   },
                   "gridHost": "100.100.100.100",
                   "wapiPort": 443,
-                  "wapiVersion": "2.3.1"
+                  "wapiVersion": "2.12.2"
                 },
                 "type": "Infoblox"
               },
@@ -328,7 +356,7 @@ properties:
       features.operators.openshift.io/token-auth-aws: "false"
       features.operators.openshift.io/token-auth-azure: "false"
       features.operators.openshift.io/token-auth-gcp: "false"
-      olm.skipRange: <1.3.0
+      olm.skipRange: <1.3.1
       operatorframework.io/suggested-namespace: external-dns-operator
       operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
         "OpenShift Container Platform", "OpenShift Platform Plus"]'

--- a/catalog/external-dns-operator/channel.yaml
+++ b/catalog/external-dns-operator/channel.yaml
@@ -3,10 +3,10 @@ schema: olm.channel
 name: stable-v1
 package: external-dns-operator
 entries:
-  - name: external-dns-operator.v1.3.0
+  - name: external-dns-operator.v1.3.1
 ---
 schema: olm.channel
 name: stable-v1.3
 package: external-dns-operator
 entries:
-  - name: external-dns-operator.v1.3.0
+  - name: external-dns-operator.v1.3.1


### PR DESCRIPTION
Updated the bundle image with contents from commit 75de5293cbf436b4971384664e4982e136f93b41 and regenerated the catalog using `make catalog`.

Steps performed:
- Built and pushed the bundle image:
  - `podman build -t quay.io/external-dns-operator/external-dns-operator-bundle:latest -f Dockerfile.bundle .`
  - `podman push quay.io/external-dns-operator/external-dns-operator-bundle:latest`
- Generated FBC with `make catalog`.

Continuation of https://github.com/openshift/external-dns-operator/pull/275. This PR updates the FBC contents from the latest bundle.