### PR TITLE
OCPBUGS-24656: Ensure FIPS compliance for operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .
+RUN git config --global --add safe.directory /opt/app-root/src
 
 # Build
 RUN make build-operator
 
 # Use minimal base image to package the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/external-dns-operator .
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ OPERATOR_SDK_BIN=$(BIN_DIR)/operator-sdk
 
 COMMIT ?= $(shell git rev-parse HEAD)
 SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
-GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)"
+GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)" -tags strictfipsruntime
+CHECK_PAYLOAD_IMG ?= registry.ci.openshift.org/ci/check-payload:latest
 
 E2E_TIMEOUT ?= 1h
 TEST_PKG ?= ./test/e2e
@@ -135,7 +136,7 @@ verify: lint
 	hack/verify-version.sh
 
 ##@ Build
-GO=GO111MODULE=on GOFLAGS=-mod=vendor CGO_ENABLED=0 go
+GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 
 build-operator: ## Build operator binary, no additional checks or code generation
 	$(GO) build $(GOBUILD_VERSION_ARGS) -o $(BIN) $(PACKAGE)
@@ -150,6 +151,10 @@ image-build: test ## Build container image with the operator.
 
 image-push: ## Push container image with the operator.
 	$(CONTAINER_ENGINE) push ${IMG} ${CONTAINER_PUSH_ARGS}
+
+.PHONY: image-fips-scan
+image-fips-scan:
+	$(CONTAINER_ENGINE) run --privileged $(CHECK_PAYLOAD_IMG) scan operator --spec $(IMG)
 
 ##@ Deployment
 

--- a/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/external-dns-operator.clusterserviceversion.yaml
@@ -304,7 +304,7 @@ metadata:
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/external-dns-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     containerImage: quay.io/openshift/origin-external-dns-operator:latest
     createdAt: 2021/09/28
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,14 +1,15 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .
+RUN git config --global --add safe.directory /opt/app-root/src
 
 # Build
 RUN make build-operator
 
 # Use minimal base image to package the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/external-dns-operator .
 


### PR DESCRIPTION
This commit addresses the bug by implementing the following changes:
- Updated the builder image to be FIPS-capable.
- Added builder workdir to safe directories after builder image change.
- Enabled dynamic linkage for the operator binary (`CGO_ENABLED=1`).
- Added the strictfipsruntime tag to the operator binary.
- Changed base image to ubi-minimal because it has OpenSSL.
- Set fips-compliant annotation to true in CSV.

Additionally, implemented `image-fips-scan` make target for FIPS compliance checks.