### PR TITLE
OCPBUGS-75508, OCPBUGS-76245: Change v1.2.1 bundle relatedImages to `registry.redhat.io/edo/`

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8-operator@sha256:4c77826b31623e1362c5dfcb9d1c9a69d166c3acf3d0c31dddd12992affeab6a'
+export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8-operator@sha256:4c77826b31623e1362c5dfcb9d1c9a69d166c3acf3d0c31dddd12992affeab6a'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8@sha256:9f60c682b44497d9736a04991c0d2b3485d477f6c89a87c4a44a211a3d1f3cd4'
+export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8@sha256:9f60c682b44497d9736a04991c0d2b3485d477f6c89a87c4a44a211a3d1f3cd4'
 # kube-rbac-proxy
 # Latest version of v4.14 tag is used.
 # Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548


### PR DESCRIPTION
Update the image references in `bundle-hack/container_digest.sh` from `registry.stage.redhat.io/edo/*` to `registry.redhat.io/edo/*` as a prerequisite to the v1.2.1 production release of ExternalDNS Operator.