### PR TITLE
NO-JIRA: Fix circular dependency in operator push pipeline

### DIFF
--- a/.tekton/external-dns-operator-container-ext-dns-optr-1-2-rhel-8-push.yaml
+++ b/.tekton/external-dns-operator-container-ext-dns-optr-1-2-rhel-8-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.2"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.2" && body.repository.full_name == "openshift/external-dns-operator" && !"bundle-hack/container_digest.sh".pathChanged()
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ext-dns-optr-1-2-rhel-8


### PR DESCRIPTION
## Summary
- Add `!"bundle-hack/container_digest.sh".pathChanged()` filter to the operator push pipeline CEL expression on `release-1.2`, matching what's already done on `main`
- Without this, merging a nudge PR (which updates `container_digest.sh`) triggers an unnecessary operator rebuild, producing a new digest mismatch and another nudge PR — an endless loop
- This was preventing successful releases because the bundle CSV operator digest never matched the operator in the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)