### PR TITLE
OCPBUGS-76243: Change bundle relatedImages to registry.stage.redhat.io/edo/

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-container-ext-dns-optr-1-1-rhel-8@sha256:4701682a0eb7e666999073a29c286ea15e2e78ab9db380f246f81c2354ab9323'
+export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8-operator@sha256:4701682a0eb7e666999073a29c286ea15e2e78ab9db380f246f81c2354ab9323'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-container-ext-dns-optr-1-1-rhel-8@sha256:7c5b02e47f3f15d9cebeb0f0165616ad40ee5979e38a0aafc1678b6a3c69f9ce'
+export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8@sha256:7c5b02e47f3f15d9cebeb0f0165616ad40ee5979e38a0aafc1678b6a3c69f9ce'
 # kube-rbac-proxy
 # Latest version of v4.14 tag is used.
 # Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548


### PR DESCRIPTION
Move image references from `quay.io/redhat-user-workloads` to `registry.stage.redhat.io/edo` as a prerequisite to `v1.1.2` stage release.