### PR TITLE
OCPBUGS-79591: Bump Golang to v1.25.8 and golangci-lint to v2.10.1

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.21
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,35 +1,17 @@
 # This file contains all available configuration options
 # with their default values.
 
+version: "2"
+
 # options for analysis running
 run:
   # default concurrency is a available CPU number
   concurrency: 4
-
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
-
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
-  tests: true
   # list of build tags, all linters use it. Default is empty list.
   build-tags:
     - e2e
-
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work
-  # on Windows.
-  issues:
-    exclude-dirs:
-      - vendor
-    exclude-dirs-use-default: true
-    uniq-by-line: true
-
   # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit
   # automatic updating of go.mod described above. Instead, it fails when any changes
@@ -39,49 +21,60 @@ run:
   # directory holds the correct copies of dependencies and ignores
   # the dependency descriptions in go.mod.
   modules-download-mode: vendor
-
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+  # include test files or not, default is true
+  tests: true
   # Allow multiple parallel golangci-lint instances running.
   # If false (default) - golangci-lint acquires file lock on start.
   allow-parallel-runners: false
-
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  # default is "colored-line-number"
   formats:
-    - format: tab
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
+    tab:
+      path: stdout
+      # print linter name in the end of issue text, default is true
+      print-linter-name: true
   # add a prefix to the output file references; default is no prefix
   path-prefix: ""
-
-  # sorts results by: filepath, line and column
-  sort-results: false
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
-    - typecheck
     - unused
-  fast: false
-
-linters-settings:
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/openshift/external-dns-operator
-
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  # make issues output unique by line
+  uniq-by-line: true
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes
+      local-prefixes:
+        - github.com/openshift/external-dns-operator
+  exclusions:
+    # enables skipping of directories:
+    # vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -9,7 +9,7 @@ COPY Dockerfile .
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1763548439 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/external-dns-operator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go v60.1.0+incompatible

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-GOLANGCI_VERSION="1.64.8"
+GOLANGCI_VERSION="2.10.1"
 
 OUTPUT_PATH=${1:-./bin/golangci-lint}
 
@@ -10,10 +10,10 @@ GOARCH=$(go env GOARCH)
 
 case $GOOS in
   linux)
-    CHECKSUM="b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e"
+    CHECKSUM="dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99"
     ;;
   darwin)
-    CHECKSUM="b52aebb8cb51e00bfd5976099083fbe2c43ef556cef9c87e58a8ae656e740444"
+    CHECKSUM="66fb0da81b8033b477f97eea420d4b46b230ca172b8bb87c6610109f3772b6b6"
     ;;
     *)
     echo "Unsupported OS $GOOS"

--- a/pkg/operator/controller/externaldns/deployment_test.go
+++ b/pkg/operator/controller/externaldns/deployment_test.go
@@ -4062,7 +4062,7 @@ func TestExternalDNSDeploymentChanged(t *testing.T) {
 			expect:             false,
 			originalDeployment: testDeploymentWithVolumes(testSecretVolume("testcreds", "testsecret", "creds", "/run/secrets")),
 			mutate: func(dep *appsv1.Deployment) {
-				dep.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.DefaultMode = nil
+				dep.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = nil
 			},
 		},
 		{
@@ -4070,7 +4070,7 @@ func TestExternalDNSDeploymentChanged(t *testing.T) {
 			expect:             false,
 			originalDeployment: testDeploymentWithVolumes(testConfigMapVolume("testcerts", "testcerts", "key", "/etc/pki/trust")),
 			mutate: func(dep *appsv1.Deployment) {
-				dep.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode = nil
+				dep.Spec.Template.Spec.Volumes[0].ConfigMap.DefaultMode = nil
 			},
 		},
 		{

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -118,6 +118,7 @@ func ExternalDNSCredentialsSecretNameFromProvider(externalDNS *operatorv1beta1.E
 func hashString(str string) string {
 	hasher := getHasher()
 	hasher.Write([]byte(str))
+	//nolint:staticcheck // QF1010: fmt.Sprint is used intentionally to get string representation of byte slice
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum(nil)))
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       ]
     },
     {
-      "description": "Keep Go toolset on minor version 1.24",
+      "description": "Keep Go toolset on minor version 1.25",
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
         "Containerfile.external-dns-operator"
@@ -35,7 +35,7 @@
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^1\\.24(\\.|$)/",
+      "allowedVersions": "/^1\\.25(\\.|$)/",
       "schedule": [
         "after 5am on tuesday"
       ]

--- a/test/e2e/azure.go
+++ b/test/e2e/azure.go
@@ -121,7 +121,7 @@ func (a *azureTestHelper) ensureHostedZone(zoneDomain string) (string, []string,
 	if err != nil {
 		return "", []string{}, err
 	}
-	return *z.ID, *z.ZoneProperties.NameServers, nil
+	return *z.ID, *z.NameServers, nil
 }
 
 func (a *azureTestHelper) deleteHostedZone(zoneID, zoneDomain string) error {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -157,7 +157,7 @@ func routeExternalDNS(name, zoneID, zoneDomain, routerName string) operatorv1bet
 	// this additional check can be removed with latest external-dns image (>v0.10.1)
 	// instantiate the route additional information at ExternalDNS initiation level.
 	if routerName != "" {
-		extDns.Spec.Source.ExternalDNSSourceUnion.OpenShiftRoute = &operatorv1beta1.ExternalDNSOpenShiftRouteOptions{
+		extDns.Spec.Source.OpenShiftRoute = &operatorv1beta1.ExternalDNSOpenShiftRouteOptions{
 			RouterName: routerName,
 		}
 	}
@@ -183,7 +183,7 @@ func routeExternalDNSV1Alpha1(name, zoneID, zoneDomain, routerName string) opera
 	// this additional check can be removed with latest external-dns image (>v0.10.1)
 	// instantiate the route additional information at ExternalDNS initiation level.
 	if routerName != "" {
-		extDns.Spec.Source.ExternalDNSSourceUnion.OpenShiftRoute = &operatorv1alpha1.ExternalDNSOpenShiftRouteOptions{
+		extDns.Spec.Source.OpenShiftRoute = &operatorv1alpha1.ExternalDNSOpenShiftRouteOptions{
 			RouterName: routerName,
 		}
 	}


### PR DESCRIPTION
- Bump Go version to v1.25.8
- Bump golangci-lint to v2.10.1 as a compatible version with Golang 1.25. Migrate `.golangci.yaml` to version `2`.
- Resolve issues highlighted by new version of golangci-lint:
```
pkg/operator/controller/externaldns/deployment_test.go:4065:39  staticcheck  QF1008: could remove embedded field "VolumeSource" from selector
pkg/operator/controller/externaldns/deployment_test.go:4073:39  staticcheck  QF1008: could remove embedded field "VolumeSource" from selector
pkg/operator/controller/names.go:121:42                         staticcheck  QF1010: could convert argument to string
test/e2e/azure.go:124:19                                        staticcheck  QF1008: could remove embedded field "ZoneProperties" from selector
test/e2e/util.go:160:22                                         staticcheck  QF1008: could remove embedded field "ExternalDNSSourceUnion" from selector
test/e2e/util.go:186:22                                         staticcheck  QF1008: could remove embedded field "ExternalDNSSourceUnion" from selector
```