### PR TITLE
OCPBUGS-76243: Add image mirrors for external-dns-operator 1-1 components

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -16,10 +16,13 @@ spec:
         - brew.registry.redhat.io/ubi9/ubi-minimal
     - source: registry.stage.redhat.io/edo/external-dns-operator-bundle
       mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-1-rhel-8
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-2-rhel-8
     - source: registry.stage.redhat.io/edo/external-dns-rhel8-operator
       mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-container-ext-dns-optr-1-1-rhel-8
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-operator-container-ext-dns-optr-1-2-rhel-8
     - source: registry.stage.redhat.io/edo/external-dns-rhel8
       mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-container-ext-dns-optr-1-1-rhel-8
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-container-ext-dns-optr-1-2-rhel-8


### PR DESCRIPTION
  Adds image mirrors for external-dns-operator 1-1 components to support the v1.1.2 stage bundle.

  The ImageDigestMirrorSet now lists multiple mirrors per source:
  - `ext-dns-optr-1-1-rhel-8` (for v1.1.x images)
  - `ext-dns-optr-1-2-rhel-8` (for v1.2.x images)
                                                                                                                     
  When pulling an image, OpenShift matches by digest (sha256 hash) and tries each mirror in order until it finds the 
  requested digest. This allows both v1.1 and v1.2 images to be pulled from the same source registry with automatic 
  fallback to the correct mirror based on the image digest.