### PR TITLE
NE-2649: Change v1.1.2 bundle relatedImages to registry.redhat.io/edo/

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8-operator@sha256:0cdc439a39fb8998c61290686226738b5185e1a663a936021edbb5208a13619d'
+export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8-operator@sha256:0cdc439a39fb8998c61290686226738b5185e1a663a936021edbb5208a13619d'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8@sha256:7c5b02e47f3f15d9cebeb0f0165616ad40ee5979e38a0aafc1678b6a3c69f9ce'
+export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8@sha256:7c5b02e47f3f15d9cebeb0f0165616ad40ee5979e38a0aafc1678b6a3c69f9ce'
 # kube-rbac-proxy
 # Latest version of v4.14 tag is used.
 # Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548


### PR DESCRIPTION
Update the image references in `bundle-hack/container_digest.sh` from `registry.stage.redhat.io/edo/*` to `registry.redhat.io/edo/*` as a prerequisite to the v1.1.2 production release of ExternalDNS Operator.