### PR TITLE
NO-JIRA: Add cpe label to match product security metadata

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -30,6 +30,7 @@ LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-operator-container"
 LABEL name="edo/external-dns-rhel9-operator"
 LABEL version="1.3.4"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.3::el9"
 WORKDIR /
 COPY --from=builder /workspace/bin/external-dns-operator /
 # Red Hat certified container images have licenses.


### PR DESCRIPTION
The `check-labels` release task enforces the `cpe` label to match the product security metadata. Without this override, the UBI base image `cpe` label is used, which does not match.

Example of failed check-labels job: [link](https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/ext-dns-optr-1-3-rhel-9/taskruns/managed-k4gpd-check-labels/logs).