### PR TITLE
OCPBUGS-86279: Update kube-rbac-proxy to the latest rhel9 based v4.17

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -4,6 +4,6 @@ export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9-operat
 # Controller
 export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9@sha256:d0e09840bad1051d91c204655ab445a377235db78e7d9a45fa0bc3c69e86e188'
 # kube-rbac-proxy
-# Latest version of v4.14 tag is used.
-# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548
-export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:ba9ff4c933739f1774bc8277d636053c5306863221a8c7b7b9ddc4470eb7feff'
+# Latest version of v4.17 tag is used.
+# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a0daee8c15dfff5626b21b5
+export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:0185c66b6ff250fddb837d5bcafcd87f089012e9157254d356f72a2620327eab'


### PR DESCRIPTION
Updates kube-rbac-proxy pullspec to the latest digest of `v4.17` floating tag. This is also a change from the rhel8 based image to ose-kube-rbac-proxy-rhel9.