### PR TITLE
NE-2730: Bump `go-toolset` to 1.25.8 and update `ubi-minimal` digest

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -9,7 +9,7 @@ COPY Dockerfile .
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7-1771287729 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8-1776905877 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace
@@ -25,7 +25,7 @@ RUN git config --global --add safe.directory /workspace
 # Build
 RUN make build-operator
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:41c6aeb7c681d89b63b35dbb8168875cd2e7b00e9ebe1d2d3d6a3c205c9dba10
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:f0ed53122215c6cccdc992166caa9f6b56c08b202e8b1144dd1c2ad04579415d
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-operator-container"
 LABEL name="external-dns-operator"


### PR DESCRIPTION
Update `go-toolset` from 1.25.7 to 1.25.8 to match the operand, and refresh the `ubi-minimal` base image digest.
This is supposed to catch up on missed renovate updates (see https://github.com/openshift/external-dns-operator/pull/460).