### PR TITLE
NE-2727: Change bundle relatedImages to registry.stage.redhat.io/edo/

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9-operator@sha256:1595225bc2cd0f84ffd97375b55345490c9b62181bcd3648dda92281bc17af9b'
+export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel9-operator@sha256:1595225bc2cd0f84ffd97375b55345490c9b62181bcd3648dda92281bc17af9b'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9@sha256:9890936faaada0886ce0782315f0a4da6d34a0783cdce5f6dab185e4117168d6'
+export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel9@sha256:9890936faaada0886ce0782315f0a4da6d34a0783cdce5f6dab185e4117168d6'
 # kube-rbac-proxy
 # Latest version of v4.17 tag is used.
 # Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a0daee8c15dfff5626b21b5


### PR DESCRIPTION
As a prerequisite to the v1.3.5 stage registry release change the bundle relatedImages to `registry.stage.redhat.io/edo/`.