### PR TITLE
NE-2730: Update kube-rbac-proxy to the latest rhel8 based v4.15

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -4,6 +4,6 @@ export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8-operat
 # Controller
 export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8@sha256:65b8adf165bf8ad7fabcc8915f63e3d99bc172f8b9441fcdea5b9856b73ea980'
 # kube-rbac-proxy
-# Latest version of v4.14 tag is used.
-# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548
-export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:ba9ff4c933739f1774bc8277d636053c5306863221a8c7b7b9ddc4470eb7feff'
+# Latest version of v4.15 tag is used.
+# Catalog link (health grade B): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=6a047feb2defcf172d2f13ab
+export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:814e0ec7d531113a01b327a1f8719e4d42ec4b6683b96728c5bcfab4a3a4ebcf'


### PR DESCRIPTION
## Summary
- Update kube-rbac-proxy pullspec from v4.14 to v4.15 (latest available for rhel8)
- The rhel8 `ose-kube-rbac-proxy` is only available up to v4.15; v4.17+ moved to the rhel9 variant (`ose-kube-rbac-proxy-rhel9`)
- This brings the health grade from D to B, which is the best achievable for rhel8
- Equivalent of [PR #459](https://github.com/openshift/external-dns-operator/pull/459) (which updated main/1.3 to rhel9 v4.17)
- Part of the EDO v1.2.2 release ([NE-2730](https://redhat.atlassian.net/browse/NE-2730))

## Changes
- `bundle-hack/container_digest.sh`: kube-rbac-proxy digest updated to v4.15 floating tag

## Note
This change only updates the pullspec in `container_digest.sh`. The nudging PRs (#449, #456) will separately update the operator and operand digests once the 1.2.2 builds complete.