### PR TITLE
NE-2727: Add image mirrors for external-dns-operator 1-3 components

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -18,6 +18,7 @@ spec:
       mirrors:
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-1-rhel-8
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-2-rhel-8
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-operator-bundle-container-ext-dns-optr-1-3-rhel-9
     - source: registry.stage.redhat.io/edo/external-dns-rhel8-operator
       mirrors:
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-container-ext-dns-optr-1-1-rhel-8
@@ -26,3 +27,9 @@ spec:
       mirrors:
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-container-ext-dns-optr-1-1-rhel-8
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-container-ext-dns-optr-1-2-rhel-8
+    - source: registry.stage.redhat.io/edo/external-dns-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-operator-container-ext-dns-optr-1-3-rhel-9
+    - source: registry.stage.redhat.io/edo/external-dns-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-container-ext-dns-optr-1-3-rhel-9


### PR DESCRIPTION
Adds image mirrors for external-dns-operator 1-3 components to support the v1.3.x stage bundles.

Similar to #422.