### PR TITLE
NE-2727: Prevent unnecessary operator and bundle builds

### DIFF
--- a/.tekton/external-dns-operator-bundle-container-ext-dns-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/external-dns-operator-bundle-container-ext-dns-optr-1-3-rhel-9-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && !files.all.all(f, f.matches('^catalog/'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ext-dns-optr-1-3-rhel-9

--- a/.tekton/external-dns-operator-container-ext-dns-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/external-dns-operator-container-ext-dns-optr-1-3-rhel-9-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && body.repository.full_name == "openshift/external-dns-operator" && !"bundle-hack/container_digest.sh".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && body.repository.full_name == "openshift/external-dns-operator" && !files.all.all(f, f.matches('^bundle-hack/container_digest\\.sh$') || f.matches('^bundle/') || f.matches('^catalog/'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ext-dns-optr-1-3-rhel-9


### PR DESCRIPTION
Disable the operator on-push (merge) pipeline from running if the changes only affect the following directories:
- `bundle-hack/container_digest.sh`
- `catalog/`
- `bundle/`

Disable the bundle on-push pipeline from running if the changes only affect the `catalog/` directory.

The pipelines will run if there are changes to any other file outside of that list also present in the merged changes.

Following the pipelines as code docs [example](https://pipelinesascode.com/docs/guide/matchingevents/#filtering-pipelineruns-to-exclude-non-code-changes) and a similar change already made in https://github.com/openshift/aws-load-balancer-operator/pull/261.