### PR TITLE
NE-2727: Change v1.3.5 bundle relatedImages to registry.redhat.io/edo/

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel9-operator@sha256:b6ba8a87c9541fd5b4e18417bfb5478d1cb1a3e7986d8fb2fb9d5199ba8dcdc2'
+export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9-operator@sha256:b6ba8a87c9541fd5b4e18417bfb5478d1cb1a3e7986d8fb2fb9d5199ba8dcdc2'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel9@sha256:9890936faaada0886ce0782315f0a4da6d34a0783cdce5f6dab185e4117168d6'
+export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9@sha256:9890936faaada0886ce0782315f0a4da6d34a0783cdce5f6dab185e4117168d6'
 # kube-rbac-proxy
 # Latest version of v4.17 tag is used.
 # Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a0daee8c15dfff5626b21b5


### PR DESCRIPTION
Update the image references in `bundle-hack/container_digest.sh` from `registry.stage.redhat.io/edo/*` to `registry.redhat.io/edo/*` as a prerequisite to the v1.3.5 production release of ExternalDNS Operator.