### PR TITLE
NO-JIRA: Add registry.redhat.io/edo/* image mirrors and fix mirror set size limit

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -14,6 +14,25 @@ spec:
     - source: registry.redhat.io/ubi9/ubi-minimal
       mirrors:
         - brew.registry.redhat.io/ubi9/ubi-minimal
+    - source: registry.redhat.io/edo/external-dns-operator-bundle
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-1-rhel-8
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-2-rhel-8
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-operator-bundle-container-ext-dns-optr-1-3-rhel-9
+    - source: registry.redhat.io/edo/external-dns-rhel8-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-container-ext-dns-optr-1-1-rhel-8
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-operator-container-ext-dns-optr-1-2-rhel-8
+    - source: registry.redhat.io/edo/external-dns-rhel8
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-container-ext-dns-optr-1-1-rhel-8
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-2-rhel-8/external-dns-container-ext-dns-optr-1-2-rhel-8
+    - source: registry.redhat.io/edo/external-dns-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-operator-container-ext-dns-optr-1-3-rhel-9
+    - source: registry.redhat.io/edo/external-dns-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-container-ext-dns-optr-1-3-rhel-9
     - source: registry.stage.redhat.io/edo/external-dns-operator-bundle
       mirrors:
         - quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-1-rhel-8/external-dns-operator-bundle-container-ext-dns-optr-1-1-rhel-8

--- a/.tekton/pipelines/deploy-fbc-operator.yaml
+++ b/.tekton/pipelines/deploy-fbc-operator.yaml
@@ -125,8 +125,6 @@ spec:
         workspaces:
           - name: shared-data
         results:
-          - name: serializedMirrorSetYaml
-            description: "A serialized string of an ImageDigestMirrorSet YAML, where each mirror entry is formatted with escaped newlines to preserve structure in a single-line format"
           - name: scorecardConfigImages
             description: "Images pulled from the scorecard config YAML."
         steps:
@@ -215,8 +213,7 @@ spec:
 
               serialized_mirror_set=$(serialize_image_mirrors_yaml "${mirror_set_yaml}")
               echo "Serialized image mirror set: $serialized_mirror_set"
-
-              echo -e "$serialized_mirror_set" > "$(results.serializedMirrorSetYaml.path)"
+              echo -e "$serialized_mirror_set" > "$(workspaces.shared-data.path)/serializedMirrorSetYaml"
 
               # Fetch scorecard config
               scorecard_config_url="${SOURCE_GIT_URL}/raw/${SOURCE_GIT_REVISION}/bundle/tests/scorecard/config.yaml"
@@ -438,7 +435,11 @@ spec:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: in
           values: ["pull_request", "ok-to-test-comment", "retest-all-comment"]
+      workspaces:
+        - name: shared-data
       taskSpec:
+        workspaces:
+          - name: shared-data
         results:
           - name: clusterName
             value: "$(steps.create-cluster.results.clusterName)"
@@ -473,8 +474,8 @@ spec:
                 value: "$(steps.get-latest-version-tag.results.version)"
               - name: instanceType
                 value: "$(tasks.pick-cluster-params.results.bundleArch)"
-              - name: imageContentSources
-                value: "$(tasks.fetch-config-files.results.serializedMirrorSetYaml)"
+              - name: imageContentSourcesFile
+                value: "$(workspaces.shared-data.path)/serializedMirrorSetYaml"
     - name: deploy-operator
       runAfter:
         - provision-cluster


### PR DESCRIPTION
Pass the serialized image mirror set via the `shared-data` workspace instead of a Tekton task result to avoid the 4096-byte size limit. Use the `imageContentSourcesFile` parameter of `eaas-create-ephemeral-cluster-hypershift-aws` step action.

Add `registry.redhat.io/edo/*` mirror entries pointing to Konflux builds, matching the existing `registry.stage.redhat.io/edo/*` mirrors. This allows the bundle `relatedImages` to reference `registry.redhat.io/edo/*` from the start, avoiding the manual registry change to `registry.stage.redhat.io`.