### PR TITLE
NE-2730: Switch container digests to stage registry for 1.2.2 release

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,8 +1,8 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8-operator@sha256:cb6bdce66f1c6808c841dbef4a37afa7d62768713e42dfbe6a08992626736fcc'
+export OPERATOR_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8-operator@sha256:cb6bdce66f1c6808c841dbef4a37afa7d62768713e42dfbe6a08992626736fcc'
 # Controller
-export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel8@sha256:49049975ef00ebb839445f054e03b8603c33c4f09dccfc48685c96412d30cf3d'
+export OPERAND_IMAGE_PULLSPEC='registry.stage.redhat.io/edo/external-dns-rhel8@sha256:49049975ef00ebb839445f054e03b8603c33c4f09dccfc48685c96412d30cf3d'
 # kube-rbac-proxy
 # Latest version of v4.15 tag is used.
 # Catalog link (health grade B): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=6a047feb2defcf172d2f13ab


### PR DESCRIPTION
## Summary
- Switch operator and operand pullspecs in `container_digest.sh` from `registry.redhat.io` to `registry.stage.redhat.io`
- Digests remain the same as the nudging PRs (#449, #456)
- Required for the stage release pipeline to pass the Conforma test ([ref: release process doc](https://github.com/openshift/external-dns-operator/pull/391))

## Context
Per the [Konflux release process](https://github.com/openshift/external-dns-operator/pull/391):
> In order for the stage release pipeline to pass the Conforma test, the registry/repository in `bundle-hack/container_digest.sh` must be set to `registry.stage.redhat.io/edo/*`. Keep the digests the same as the ones created by the nudging PR.

## Note
After stage release is verified, a follow-up PR will swap back to `registry.redhat.io` for the production release.