### PR TITLE
NO-JIRA: Add candidate tag to v4.22 FBC push pipeline

### DIFF
--- a/.tekton/external-dns-fbc-container-ext-dns-optr-fbc-v4-22-push.yaml
+++ b/.tekton/external-dns-fbc-container-ext-dns-optr-fbc-v4-22-push.yaml
@@ -307,6 +307,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["candidate"]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary
- The `ADDITIONAL_TAGS: ["candidate"]` parameter was missing from the `apply-tags` task in the v4.22 FBC push pipeline, while v4.19–v4.21 already had it.