### PR TITLE
OCPBUGS-82447: Bump Go to 1.25.9 to fix CVE-2026-32282

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/external-dns-operator
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go v60.1.0+incompatible


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` from `1.25.0` to `1.25.9` to address [CVE-2026-32282](https://nvd.nist.gov/vuln/detail/CVE-2026-32282)
- Go 1.25.0–1.25.8 are affected: `Root.Chmod` can follow symlinks out of the root directory on Linux due to `fchmodat` silently ignoring `AT_SYMLINK_NOFOLLOW`
- No application code changes — toolchain version bump only
- Dockerfiles are fine because:
     
  - Containerfile.external-dns-operator (Konflux/production build) — already pinned to go-toolset:1.25.9-1778675823, which is the patched version. No change needed.
  - Dockerfile (upstream/CI build) — uses the floating tag go-toolset:1.25, which resolves to the latest 1.25.x image in Red Hat's registry (currently 1.25.9). Even if someone happened to pull a stale cached image, the go 1.25.9
  directive we just set in go.mod would force the Go toolchain to download and use Go 1.25.9 at build time. So it's covered from both sides.
  - drift-cache/Dockerfile — must be a SHA1-identical copy of Dockerfile (enforced by the Containerfile's drift detection stage). Since Dockerfile is unchanged, this stays in sync.

## Verification

- `make build-operator` passes
- All unit tests pass (`make test` — `covdata` error is pre-existing local toolchain issue, not related to this change)
- `go fmt` and `go vet` clean

## Test plan

- [x] `make build-operator` succeeds
- [x] All unit test packages pass
- [x] `go vet ./...` clean
- [x] No vendor changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-82447`