### PR TITLE
NO-JIRA: Add cpe label to match product security metadata

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -30,6 +30,7 @@ LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-operator-container"
 LABEL name="external-dns-operator"
 LABEL version="1.2.2"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.2::el8"
 WORKDIR /
 COPY --from=builder /workspace/bin/external-dns-operator /
 # Red Hat certified container images have licenses.


### PR DESCRIPTION
## Summary

- Add `cpe` label to `Containerfile.external-dns-operator` for rhel8/1.2.x
- The `check-labels` Konflux release task enforces the `cpe` label to match the product data file — without this override, the UBI base image `cpe` label is used, which does not match
- Cherry-pick of 263ba20 from `main` (PR #446 by @alebedev87), adapted for rhel8 (`el8`, `1.2`)

/hold
Coordinating with Davide on the 1.2.3 release development

cc @alebedev87

Assisted-By: Claude