### PR TITLE
NE-2780: Add cpe label to bundle Containerfile

### DIFF
--- a/Containerfile.external-dns-operator-bundle
+++ b/Containerfile.external-dns-operator-bundle
@@ -45,6 +45,7 @@ ARG GIT_URL
 
 LABEL name=external-dns-operator-bundle
 LABEL version="1.2.2"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.2::el8"
 LABEL maintainer='NetworkEdge team <aos-network-edge-staff@redhat.com>'
 LABEL io.k8s.display-name='ExternalDNS Operator'
 LABEL io.k8s.description='Operator bundle for the ExternalDNS Operator'


### PR DESCRIPTION
Adds the required `cpe` label to `Containerfile.external-dns-operator-bundle` for the release-1.2 branch.

Without it, the bundle image fails the `labels.required_labels` violation during release.

Cherry-pick equivalent of the label added on `main` in PR #446, adapted for rhel8.