### PR TITLE
OCPBUGS-85454, OCPBUGS-85964, OCPBUGS-82445: Bump to go v1.25.10

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -9,7 +9,7 @@ COPY Dockerfile .
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7-1771287729 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace


### PR DESCRIPTION
Bump go version to v1.25.10 for security fixes, notably fixes for CVE-2026-32280, CVE-2026-32281, CVE-2026-32282, and CVE-2026-32283.

This bug fixes OCPBUGS-85454, OCPBUGS-85964, OCPBUGS-82445, and OCPBUGS-83268.