### PR TITLE
OCPBUGS-97605: Use static ServiceAccount for operand

### DIFF
--- a/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -11,6 +11,3 @@ subjects:
 - kind: ServiceAccount
   name: external-dns
   namespace: external-dns-operator
-- kind: Group
-  name: system:serviceaccounts:external-dns-operator
-  namespace: external-dns-operator

--- a/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/external-dns_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -8,9 +8,9 @@ roleRef:
   kind: ClusterRole
   name: external-dns
 subjects:
-- kind: Group
-  name: system:serviceaccounts:external-dns
-  namespace: external-dns
+- kind: ServiceAccount
+  name: external-dns
+  namespace: external-dns-operator
 - kind: Group
   name: system:serviceaccounts:external-dns-operator
   namespace: external-dns-operator

--- a/config/rbac/operand_rolebinding.yaml
+++ b/config/rbac/operand_rolebinding.yaml
@@ -8,9 +8,9 @@ roleRef:
   kind: ClusterRole
   name: external-dns
 subjects:
-  - kind: Group
-    name: system:serviceaccounts:external-dns
-    namespace: external-dns
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: external-dns-operator
   - kind: Group
     name: system:serviceaccounts:external-dns-operator
     namespace: external-dns-operator

--- a/config/rbac/operand_rolebinding.yaml
+++ b/config/rbac/operand_rolebinding.yaml
@@ -11,6 +11,3 @@ subjects:
   - kind: ServiceAccount
     name: external-dns
     namespace: external-dns-operator
-  - kind: Group
-    name: system:serviceaccounts:external-dns-operator
-    namespace: external-dns-operator

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -10,10 +10,22 @@ GOARCH=$(go env GOARCH)
 
 case $GOOS in
   linux)
-    CHECKSUM="dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99"
+    if [ "$GOARCH" = "amd64" ]; then
+      CHECKSUM="dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99"
+    else
+      echo "Unsupported architecture $GOARCH for $GOOS"
+      exit 1
+    fi
     ;;
   darwin)
-    CHECKSUM="66fb0da81b8033b477f97eea420d4b46b230ca172b8bb87c6610109f3772b6b6"
+    if [ "$GOARCH" = "amd64" ]; then
+      CHECKSUM="66fb0da81b8033b477f97eea420d4b46b230ca172b8bb87c6610109f3772b6b6"
+    elif [ "$GOARCH" = "arm64" ]; then
+      CHECKSUM="03bfadf67e52b441b7ec21305e501c717df93c959836d66c7f97312654acb297"
+    else
+      echo "Unsupported architecture $GOARCH for $GOOS"
+      exit 1
+    fi
     ;;
     *)
     echo "Unsupported OS $GOOS"
@@ -21,16 +33,15 @@ case $GOOS in
     ;;
 esac
 
-if [ "$GOARCH" != "amd64" ]; then
-  echo "Unsupported architecture $GOARCH"
-  exit 1
-fi
-
 TEMPDIR=$(mktemp -d)
 curl --silent --location -o "$TEMPDIR/golangci-lint.tar.gz" "https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_VERSION/golangci-lint-$GOLANGCI_VERSION-$GOOS-$GOARCH.tar.gz"
 tar xzf "$TEMPDIR/golangci-lint.tar.gz" --directory="$TEMPDIR"
 
-echo "$CHECKSUM" "$TEMPDIR/golangci-lint.tar.gz" | sha256sum -c --quiet
+if [ "$GOOS" = "darwin" ]; then
+  echo "$CHECKSUM  $TEMPDIR/golangci-lint.tar.gz" | shasum -a 256 -c
+else
+  echo "$CHECKSUM  $TEMPDIR/golangci-lint.tar.gz" | sha256sum -c --quiet
+fi
 
 BIN=$TEMPDIR/golangci-lint-$GOLANGCI_VERSION-$GOOS-$GOARCH/golangci-lint
 mv "$BIN" "$OUTPUT_PATH"

--- a/pkg/operator/controller/externaldns/controller_test.go
+++ b/pkg/operator/controller/externaldns/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1beta1 "github.com/openshift/external-dns-operator/api/v1beta1"
+	controller "github.com/openshift/external-dns-operator/pkg/operator/controller"
 	"github.com/openshift/external-dns-operator/pkg/operator/controller/utils/test"
 )
 
@@ -90,7 +91,7 @@ func TestReconcile(t *testing.T) {
 					ObjType:   serviceAccountResource,
 					NamespacedName: types.NamespacedName{
 						Namespace: test.OperandNamespace,
-						Name:      test.OperandName,
+						Name:      controller.ExternalDNSOperandServiceAccountName(),
 					},
 				},
 				{
@@ -129,7 +130,7 @@ func TestReconcile(t *testing.T) {
 					ObjType:   serviceAccountResource,
 					NamespacedName: types.NamespacedName{
 						Namespace: test.OperandNamespace,
-						Name:      test.OperandName,
+						Name:      controller.ExternalDNSOperandServiceAccountName(),
 					},
 				},
 				{
@@ -161,7 +162,7 @@ func TestReconcile(t *testing.T) {
 					ObjType:   serviceAccountResource,
 					NamespacedName: types.NamespacedName{
 						Namespace: test.OperandNamespace,
-						Name:      test.OperandName,
+						Name:      controller.ExternalDNSOperandServiceAccountName(),
 					},
 				},
 				{

--- a/pkg/operator/controller/externaldns/service_account.go
+++ b/pkg/operator/controller/externaldns/service_account.go
@@ -32,7 +32,7 @@ import (
 
 // ensureExternalDNSServiceAccount ensures that the externalDNS service account exists.
 func (r *reconciler) ensureExternalDNSServiceAccount(ctx context.Context, namespace string, externalDNS *operatorv1beta1.ExternalDNS) (bool, *corev1.ServiceAccount, error) {
-	nsName := types.NamespacedName{Namespace: namespace, Name: controller.ExternalDNSResourceName(externalDNS)}
+	nsName := types.NamespacedName{Namespace: namespace, Name: controller.ExternalDNSOperandServiceAccountName()}
 
 	desired := desiredExternalDNSServiceAccount(namespace, externalDNS)
 
@@ -72,7 +72,7 @@ func desiredExternalDNSServiceAccount(namespace string, externalDNS *operatorv1b
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      controller.ExternalDNSResourceName(externalDNS),
+			Name:      controller.ExternalDNSOperandServiceAccountName(),
 		},
 	}
 }

--- a/pkg/operator/controller/externaldns/service_account_test.go
+++ b/pkg/operator/controller/externaldns/service_account_test.go
@@ -48,7 +48,7 @@ func TestEnsureExternalDNSServiceAccount(t *testing.T) {
 			expectedExist:   true,
 			expectedSA: corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      controller.ExternalDNSResourceName(test.ExternalDNS),
+					Name:      controller.ExternalDNSOperandServiceAccountName(),
 					Namespace: test.OperandNamespace,
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -67,7 +67,7 @@ func TestEnsureExternalDNSServiceAccount(t *testing.T) {
 			existingObjects: []runtime.Object{
 				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      controller.ExternalDNSResourceName(test.ExternalDNS),
+						Name:      controller.ExternalDNSOperandServiceAccountName(),
 						Namespace: test.OperandNamespace,
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -84,7 +84,7 @@ func TestEnsureExternalDNSServiceAccount(t *testing.T) {
 			expectedExist: true,
 			expectedSA: corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      controller.ExternalDNSResourceName(test.ExternalDNS),
+					Name:      controller.ExternalDNSOperandServiceAccountName(),
 					Namespace: test.OperandNamespace,
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -57,6 +57,11 @@ func ExternalDNSResourceName(externalDNS *operatorv1beta1.ExternalDNS) string {
 	return ExternalDNSBaseName + "-" + externalDNS.Name
 }
 
+// ExternalDNSOperandServiceAccountName returns the static ServiceAccount name for all operands.
+func ExternalDNSOperandServiceAccountName() string {
+	return ExternalDNSBaseName
+}
+
 // ExternalDNSGlobalResourceName returns the name for the resources shared among ExternalDNS instances.
 func ExternalDNSGlobalResourceName() string {
 	return ExternalDNSBaseName


### PR DESCRIPTION
When the operator is installed in a custom namespace, OLM fails to rewrite Group subjects in the ClusterRoleBinding. By standardizing the operand to use a single static ServiceAccount ('external-dns') and referencing it as a ServiceAccount subject, OLM successfully dynamically rewrites the namespace field during custom namespace installs, allowing operand pods to function correctly.

This aligns with Red Hat's philosophy that operators should be namespace-agnostic and resolves the issue where OLM fails to rewrite Group subjects for custom namespace installations.

Includes a build fix to allow the golangci-lint script to run on Apple Silicon.

Resolves: https://issues.redhat.com/browse/OCPBUGS-97605