### PR TITLE
[Project Darkstar] PSHP-558: Remediate 6 Go stdlib CVEs in external-dns-operator

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -9,7 +9,7 @@ COPY Dockerfile .
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.11 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.11 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.11 as builder
 
 WORKDIR /opt/app-root/src
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/external-dns-operator
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require (
 	github.com/Azure/azure-sdk-for-go v60.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.27


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary
- Bumps Go toolchain from 1.25.9/1.25 to 1.25.11 in all build contexts to remediate 6 Go stdlib CVEs from [PSHP-558](https://redhat.atlassian.net/browse/PSHP-558)
- Updates `Containerfile.external-dns-operator`, `Dockerfile`, `drift-cache/Dockerfile`, and `go.mod`
- Adds `toolchain go1.25.11` directive to `go.mod` (preferred over bumping the `go` minimum version for stdlib CVE fixes)

## CVE Details

| CVE | Severity | CVSS | Component | Fixed In |
|-----|----------|------|-----------|----------|
| CVE-2026-33814 | Important | 7.5 | Go stdlib (GO-2026-4918) | go1.25.10 |
| CVE-2026-33811 | Important | 7.5 | Go stdlib (GO-2026-4981) | go1.25.10 |
| CVE-2026-39820 | Important | 7.5 | Go stdlib (GO-2026-4986) | go1.25.10 |
| CVE-2026-42499 | Important | 7.5 | Go stdlib (GO-2026-4977) | go1.25.10 |
| CVE-2026-42504 | Important | 7.5 | Go stdlib (GO-2026-5038) | go1.25.11 |
| CVE-2026-27145 | Important | 7.5 | Go stdlib (GO-2026-5037) | go1.25.11 |

## Changes
- `Containerfile.external-dns-operator`: `go-toolset:1.25.9-1778675823` → `go-toolset:1.25.11`
- `Dockerfile`: `go-toolset:1.25` → `go-toolset:1.25.11`
- `drift-cache/Dockerfile`: `go-toolset:1.25` → `go-toolset:1.25.11` (kept in sync with Dockerfile for drift check)
- `go.mod`: added `toolchain go1.25.11` directive
- `go.sum`: updated checksums

## Not Fixed (Mintmaker scope)
The following CVEs from [PSHP-558](https://redhat.atlassian.net/browse/PSHP-558) affect `golang.org/x/crypto` (v0.37.0 → v0.52.0 needed) and `golang.org/x/net` (v0.39.0 → v0.55.0 needed). Per Project Darkstar policy, module bumps in MintMaker-managed repos are left to the MintMaker bot:
- CVE-2026-39828 (x/crypto, CVSS 8.8), CVE-2026-39832 (x/crypto, CVSS 8.7), CVE-2026-39821 (x/net, CVSS 8.2), and 9 additional x/crypto/x/net CVEs

MintMaker should be prompted to open an x/crypto + x/net bump PR urgently.

## Verification
- [ ] `go build ./...` passes with go1.25.11 toolchain
- [ ] `make test` passes
- [ ] No regressions in existing functionality
- [ ] Drift detection check in Containerfile still passes (Dockerfile and drift-cache/Dockerfile updated together)

## References
- Jira: [PSHP-558](https://redhat.atlassian.net/browse/PSHP-558)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-33814

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)