### PR TITLE
NE-2820: Konflux: add cpe label to match product security metadata

### DIFF
--- a/Containerfile.external-dns-operator
+++ b/Containerfile.external-dns-operator
@@ -30,6 +30,7 @@ LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-operator-container"
 LABEL name="external-dns-operator"
 LABEL version="1.1.3"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.1::el8"
 WORKDIR /
 COPY --from=builder /workspace/bin/external-dns-operator /
 # Red Hat certified container images have licenses.

--- a/Containerfile.external-dns-operator-bundle
+++ b/Containerfile.external-dns-operator-bundle
@@ -38,6 +38,7 @@ LABEL com.redhat.component=external-dns-operator-bundle-container
 LABEL com.redhat.delivery.backport: false
 # this is a bundle image and should be delivered via an index image
 LABEL com.redhat.delivery.operator.bundle: true
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.1::el8"
 
 # Define build arguments to receive dynamic values
 ARG FULL_COMMIT


### PR DESCRIPTION
`check-labels` release task enforces the `cpe` label to match the value from the product data file. Without this override, the UBI base image `cpe` label is used, which does not match and the `verify-conforma` task fails.

Example of tasks:
- [check-labels](https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/ext-dns-optr-1-1-rhel-8/taskruns/managed-82rzc-check-labels/logs)
- [verify-conforma](https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/ext-dns-optr-1-1-rhel-8/taskruns/managed-82rzc-verify-conforma/logs)

