### PR TITLE
NE-2822: Update kube-rbac-proxy to latest v4.19

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -4,6 +4,6 @@ export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9-operat
 # Controller
 export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/edo/external-dns-rhel9@sha256:f67e297f864f2eae3a40c4bb2f5e896e22891e62e058f9b8473d24171b4eb1d0'
 # kube-rbac-proxy
-# Latest version of v4.18 tag is used.
-# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a202a5cc6ecfa8d7f4125bf
-export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:0fc6a16b71e2719d9d01d6dfeb83077c38562c08d628d1f1ae03fabe3a5b9a91'
+# Latest version of v4.19 tag is used.
+# Catalog link (health grade A):https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a69e7e6e3094faea0ff8769
+export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:98f9ae97d479f92cabc782534c6dfad56588f434797f1e3d866a97810db2d323'


### PR DESCRIPTION
Bumps kube-rbac-proxy to the latest v4.19 tag image:
https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a69e7e6e3094faea0ff8769
as a regular maintenance coming up for the next 1.3 release.